### PR TITLE
dart-runtime: ignore package info error (information might not be available)

### DIFF
--- a/dart-runtime/lib/http_client.dart
+++ b/dart-runtime/lib/http_client.dart
@@ -5,8 +5,8 @@ import 'dart:math';
 import 'package:convert/convert.dart';
 import 'package:device_info/device_info.dart';
 import 'package:flutter/widgets.dart';
-import 'package:get_version/get_version.dart';
 import 'package:http/http.dart' as http;
+import 'package:package_info/package_info.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'types.dart';
@@ -62,11 +62,16 @@ class SdkgenHttpClient {
 
       var locale = context == null ? null : Localizations.localeOf(context);
 
+      PackageInfo packageInfo;
+      try {
+        packageInfo = await PackageInfo.fromPlatform();
+      } catch (e) {}
+
       var platform = {
         "os": Platform.operatingSystem,
         "osVersion": Platform.operatingSystemVersion,
         "dartVersion": Platform.version,
-        "appId": await GetVersion.appID,
+        "appId": packageInfo?.packageName,
         "screenWidth": context == null ? 0 : MediaQuery.of(context).size.width,
         "screenHeight": context == null ? 0 : MediaQuery.of(context).size.height
       };
@@ -97,7 +102,7 @@ class SdkgenHttpClient {
           "type": Platform.isAndroid
               ? "android"
               : Platform.isIOS ? "ios" : "flutter",
-          "version": await GetVersion.projectVersion
+          "version": packageInfo?.version
         }
       };
 

--- a/dart-runtime/pubspec.yaml
+++ b/dart-runtime/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   http: ^0.12.0+4
   convert: ^2.1.1
   shared_preferences: ^0.5.6+1
-  get_version: ^0.2.1
+  package_info: ^0.4.0+13
   device_info: ^0.4.1+4
   flutter:
     sdk: flutter


### PR DESCRIPTION
Fixes #11.

Note: package `get_version` was replaced by `package_info` because it was just a wrapper (see https://github.com/fluttercommunity/get_version/blob/master/lib/get_version.dart)