### PR TITLE
Fix URL import for Node 8 support

### DIFF
--- a/node-runtime/src/http-client.ts
+++ b/node-runtime/src/http-client.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "crypto";
 import { request as httpRequest } from "http";
 import { request as httpsRequest } from "https";
 import { hostname } from "os";
+import { URL } from "url";
 import { Context } from "./context";
 import { decode, encode } from "./encode-decode";
 import { SdkgenError } from "./error";


### PR DESCRIPTION
Node 8 doesn't have the `URL` global class. Instead, we need to import it from the "URL" package.