### PR TITLE
Fix: Restore old date/datetime behavior

### DIFF
--- a/browser-runtime/src/encode-decode.ts
+++ b/browser-runtime/src/encode-decode.ts
@@ -132,7 +132,7 @@ export function encode(typeTable: TypeTable, path: string, type: TypeDescription
         if (!(value instanceof Date) && !(typeof value === "string" && value.match(/^[0-9]{4}-[01][0-9]-[0123][0-9]$/))) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
-        return typeof value === "string" ? new Date(value).toISOString().split("T").shift() : value.toISOString().split("T").shift();
+        return typeof value === "string" ? new Date(value).toISOString().split("T")[0] : value.toISOString().split("T")[0];
     } else if (type === "datetime") {
         if (!(value instanceof Date) && !(typeof value === "string" && value.match(/^[0-9]{4}-[01][0-9]-[0123][0-9]T[012][0-9]:[0123456][0-9]:[0123456][0-9](\\.[0-9]{1,6})?Z?$/))) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);

--- a/browser-runtime/src/encode-decode.ts
+++ b/browser-runtime/src/encode-decode.ts
@@ -132,13 +132,11 @@ export function encode(typeTable: TypeTable, path: string, type: TypeDescription
         if (!(value instanceof Date) && !(typeof value === "string" && value.match(/^[0-9]{4}-[01][0-9]-[0123][0-9]$/))) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
-
         return typeof value === "string" ? new Date(value).toISOString().split("T").shift() : value.toISOString().split("T").shift();
     } else if (type === "datetime") {
         if (!(value instanceof Date) && !(typeof value === "string" && value.match(/^[0-9]{4}-[01][0-9]-[0123][0-9]T[012][0-9]:[0123456][0-9]:[0123456][0-9](\\.[0-9]{1,6})?Z?$/))) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
-
         return typeof value === "string" ? value.replace("Z", "") : value.toISOString().replace("Z", "");
     } else {
         const resolved = typeTable[type];

--- a/browser-runtime/src/encode-decode.ts
+++ b/browser-runtime/src/encode-decode.ts
@@ -129,15 +129,17 @@ export function encode(typeTable: TypeTable, path: string, type: TypeDescription
         }
         return value;
     } else if (type === "date") {
-        if (!(value instanceof Date)) {
+        if (!(value instanceof Date) && !(typeof value === "string" && value.match(/^[0-9]{4}-[01][0-9]-[0123][0-9]$/))) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
-        return value.toISOString().split("T")[0];
+
+        return typeof value === "string" ? new Date(value).toISOString().split("T").shift() : value.toISOString().split("T").shift();
     } else if (type === "datetime") {
-        if (!(value instanceof Date)) {
+        if (!(value instanceof Date) && !(typeof value === "string" && value.match(/^[0-9]{4}-[01][0-9]-[0123][0-9]T[012][0-9]:[0123456][0-9]:[0123456][0-9](\\.[0-9]{1,6})?Z?$/))) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
-        return value.toISOString().replace("Z", "");
+
+        return typeof value === "string" ? value.replace("Z", "") : value.toISOString().replace("Z", "");
     } else {
         const resolved = typeTable[type];
         if (resolved) {

--- a/node-runtime/spec/types/types.spec.ts
+++ b/node-runtime/spec/types/types.spec.ts
@@ -56,11 +56,11 @@ describe("Encode/Decode", () => {
     });
 
     test("Process Date", () => {
-        expect(encode({}, "", "date", new Date(2020, 10, 10))).toBe("2020-11-10");
-        expect(encode({}, "", "date", new Date(2020, 10, 10, 15, 34, 50, 999))).toBe("2020-11-10");
+        expect(encode({}, "", "date", new Date("2020-11-10T00:00:00Z"))).toBe("2020-11-10");
+        expect(encode({}, "", "date", new Date("2020-11-10T15:34:50Z"))).toBe("2020-11-10");
         expect(encode({}, "", "date", "2020-11-10")).toBe("2020-11-10");
         expect(() => {
-            encode({}, "", "date", "2020-11-10T18:34:50Z");
+            encode({}, "", "date", "2020-11-10T15:34:50Z");
         }).toThrow();
         expect(() => {
             encode({}, "", "date", "hello world");
@@ -68,8 +68,8 @@ describe("Encode/Decode", () => {
     });
 
     test("Process Datetime", () => {
-        expect(encode({}, "", "datetime", new Date(2020, 10, 10, 15, 34, 50, 999))).toBe("2020-11-10T18:34:50.999");
-        expect(encode({}, "", "datetime", "2020-11-10T18:34:50Z")).toBe("2020-11-10T18:34:50");
+        expect(encode({}, "", "datetime", new Date("2020-11-10T15:34:50Z"))).toBe("2020-11-10T15:34:50.000");
+        expect(encode({}, "", "datetime", "2020-11-10T15:34:50Z")).toBe("2020-11-10T15:34:50");
         expect(() => {
             encode({}, "", "datetime", "2020-11-10");
         }).toThrow();

--- a/node-runtime/spec/types/types.spec.ts
+++ b/node-runtime/spec/types/types.spec.ts
@@ -54,4 +54,27 @@ describe("Encode/Decode", () => {
             decode({}, "", "base64", " c3VyZS4=");
         }).toThrow();
     });
+
+    test("Process Date", () => {
+        expect(encode({}, "", "date", new Date(2020, 10, 10))).toBe("2020-11-10");
+        expect(encode({}, "", "date", new Date(2020, 10, 10, 15, 34, 50, 999))).toBe("2020-11-10");
+        expect(encode({}, "", "date", "2020-11-10")).toBe("2020-11-10");
+        expect(() => {
+            encode({}, "", "date", "2020-11-10T18:34:50Z");
+        }).toThrow();
+        expect(() => {
+            encode({}, "", "date", "hello world");
+        }).toThrow();
+    });
+
+    test("Process Datetime", () => {
+        expect(encode({}, "", "datetime", new Date(2020, 10, 10, 15, 34, 50, 999))).toBe("2020-11-10T18:34:50.999");
+        expect(encode({}, "", "datetime", "2020-11-10T18:34:50Z")).toBe("2020-11-10T18:34:50");
+        expect(() => {
+            encode({}, "", "datetime", "2020-11-10");
+        }).toThrow();
+        expect(() => {
+            encode({}, "", "datetime", "hello world");
+        }).toThrow();
+    });
 });

--- a/node-runtime/src/encode-decode.ts
+++ b/node-runtime/src/encode-decode.ts
@@ -179,7 +179,7 @@ export function encode(typeTable: TypeTable, path: string, type: TypeDescription
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
 
-        return typeof value === "string" ? new Date(value).toISOString().split("T").shift() : value.toISOString().split("T").shift();
+        return typeof value === "string" ? new Date(value).toISOString().split("T")[0] : value.toISOString().split("T")[0];
     } else if (type === "datetime") {
         if (!(value instanceof Date) && !(typeof value === "string" && value.match(/^[0-9]{4}-[01][0-9]-[0123][0-9]T[012][0-9]:[0123456][0-9]:[0123456][0-9](\\.[0-9]{1,6})?Z?$/))) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);

--- a/node-runtime/src/encode-decode.ts
+++ b/node-runtime/src/encode-decode.ts
@@ -175,7 +175,7 @@ export function encode(typeTable: TypeTable, path: string, type: TypeDescription
 
         return CNPJ.strip(value);
     } else if (type === "date") {
-        if (!(value instanceof Date) && !(typeof value === "string" && !isNaN(new Date(value).getTime()))) {
+        if (!(value instanceof Date) && !(typeof value === "string" && value.match(/^[0-9]{4}-[01][0-9]-[0123][0-9]$/))) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
 

--- a/node-runtime/src/encode-decode.ts
+++ b/node-runtime/src/encode-decode.ts
@@ -175,17 +175,17 @@ export function encode(typeTable: TypeTable, path: string, type: TypeDescription
 
         return CNPJ.strip(value);
     } else if (type === "date") {
-        if (!(value instanceof Date)) {
+        if (!(value instanceof Date) && !(typeof value === "string" && !isNaN(new Date(value).getTime()))) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
 
-        return value.toISOString().split("T")[0];
+        return typeof value === "string" ? new Date(value).toISOString().split("T").shift() : value.toISOString().split("T").shift();
     } else if (type === "datetime") {
-        if (!(value instanceof Date)) {
+        if (!(value instanceof Date) && !(typeof value === "string" && value.match(/^[0-9]{4}-[01][0-9]-[0123][0-9]T[012][0-9]:[0123456][0-9]:[0123456][0-9](\\.[0-9]{1,6})?Z?$/))) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
 
-        return value.toISOString().replace("Z", "");
+        return typeof value === "string" ? value.replace("Z", "") : value.toISOString().replace("Z", "");
     } else {
         const resolved = typeTable[type];
 


### PR DESCRIPTION
[In the previous sdkgen version, it was possible to return a string as a date/datetime and the encoder would accept it.](https://github.com/cubos/sdkgen/blob/122926fbfe2b116d51732f8a53d202b187d93739/src/codegen_types/datetime.cr#L8)

It was not possible to do that in this version, and this PR fixes that.