### PR TITLE
Deprecate 'get' and 'function' keywords by printing a warning on every usage

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -43,28 +43,28 @@ export function buildCmd(argv: string[]) {
             ]),
         );
         process.exit(0);
-        return;
     }
 
     if (!options.source) {
         console.error("Error: Missing source option.");
         process.exit(1);
-        return;
     }
 
     if (!options.output) {
         console.error("Error: Missing output option.");
         process.exit(1);
-        return;
     }
 
     if (!options.target) {
         console.error("Error: Missing target option.");
         process.exit(1);
-        return;
     }
 
     const ast = new Parser(options.source).parse();
+
+    for (const warning of ast.warnings) {
+        console.error(`WARNING: ${warning}`);
+    }
 
     switch (options.target) {
         case "typescript_nodeserver": {
@@ -90,7 +90,6 @@ export function buildCmd(argv: string[]) {
         default: {
             console.error(`Error: Unknown target '${options.target}'`);
             process.exit(1);
-            return;
         }
     }
 }

--- a/parser/spec/parser.spec.ts
+++ b/parser/spec/parser.spec.ts
@@ -29,7 +29,7 @@ describe(Parser, () => {
                 `
                     get ${p === "bool" ? "isFoo" : "foo"}(): ${p}
                     get bar(): ${p}?
-                    get baz(): ${p}[]
+                    fn getBaz(): ${p}[]
                 `,
                 {
                     errors: ["Fatal"],
@@ -50,6 +50,7 @@ describe(Parser, () => {
                     typeTable: {},
                     annotations: {},
                 },
+                ["Keyword 'get' is deprecated at -:2:21. Use 'fn' instead.", "Keyword 'get' is deprecated at -:3:21. Use 'fn' instead."],
             );
         });
     }
@@ -157,7 +158,7 @@ describe(Parser, () => {
                     b: int
                 }
 
-                get baz(): Baz
+                fn getBaz(): Baz
             `,
             {
                 errors: ["Foo", "Bar", "Fatal"],
@@ -221,7 +222,7 @@ describe(Parser, () => {
 
         expectDoesntParse(
             `
-                function foo(a: string, a: int)
+                fn foo(a: string, a: int)
             `,
             "redeclare",
         );
@@ -283,6 +284,7 @@ describe(Parser, () => {
                 },
                 annotations: {},
             },
+            ["Keyword 'function' is deprecated at -:6:17. Use 'fn' instead."],
         );
     });
 
@@ -628,10 +630,11 @@ describe(Parser, () => {
     });
 });
 
-function expectParses(source: string, json: AstJson) {
+function expectParses(source: string, json: AstJson, warnings: string[] = []) {
     const parser = new Parser(new Lexer(source));
     const ast = parser.parse();
 
+    expect(ast.warnings).toEqual(warnings);
     expect(astToJson(ast)).toEqual(json);
     expect(astToJson(ast)).toEqual(astToJson(jsonToAst(astToJson(ast))));
 }

--- a/parser/src/ast.ts
+++ b/parser/src/ast.ts
@@ -3,16 +3,15 @@ import { Token, TokenLocation } from "./token";
 export class AstRoot {
     structTypes: StructType[] = [];
     enumTypes: EnumType[] = [];
+    warnings: string[] = [];
 
     constructor(public typeDefinitions: TypeDefinition[] = [], public operations: Operation[] = [], public errors: string[] = []) {}
 }
 
 export abstract class AstNode {
     public location = new TokenLocation();
-    private kind: string;
 
     constructor() {
-        this.kind = this.constructor.name;
         Object.defineProperty(this, "location", { enumerable: false });
     }
 

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -74,6 +74,7 @@ export class Parser {
     private readonly lexers: Lexer[];
     private token: Token | null = null;
     private annotations: Annotation[] = [];
+    private warnings: string[] = [];
 
     constructor(source: Lexer | string) {
         if (!(source instanceof Lexer)) {
@@ -147,6 +148,7 @@ export class Parser {
         const operations: Operation[] = [];
         const typeDefinition: TypeDefinition[] = [];
         const errors: string[] = [];
+        this.warnings = [];
 
         while (this.token) {
             this.acceptAnnotations();
@@ -178,6 +180,7 @@ export class Parser {
         }
 
         const ast = new AstRoot(typeDefinition, operations, errors);
+        ast.warnings = this.warnings;
         analyse(ast);
         return ast;
     }
@@ -249,6 +252,10 @@ export class Parser {
             FunctionKeywordToken: token => token,
         });
         this.nextToken();
+
+        if (["get", "function"].includes(openingToken.maybeAsIdentifier().value)) {
+            this.warnings.push(`Keyword '${openingToken.maybeAsIdentifier().value}' is deprecated at ${openingToken.location}. Use 'fn' instead.`);
+        }
 
         const name = this.expect(IdentifierToken).value;
         this.nextToken();


### PR DESCRIPTION
Fixes #3