### PR TITLE
Update dependencies

### DIFF
--- a/node-runtime/package.json
+++ b/node-runtime/package.json
@@ -28,8 +28,8 @@
     "@types/request-ip": "0.0.35",
     "@types/serve-handler": "^6.1.0",
     "@types/swagger-ui-dist": "^3.0.5",
-    "@typescript-eslint/eslint-plugin": "^2.19.0",
-    "@typescript-eslint/parser": "^2.19.0",
+    "@typescript-eslint/eslint-plugin": "^2.21.0",
+    "@typescript-eslint/parser": "^2.21.0",
     "axios": "^0.19.2",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
@@ -56,13 +56,13 @@
     ]
   },
   "dependencies": {
-    "@fnando/cnpj": "^0.1.1",
-    "@fnando/cpf": "^0.1.1",
+    "@fnando/cnpj": "^1.0.1",
+    "@fnando/cpf": "^1.0.1",
     "@sdkgen/dart-generator": "file:../dart-generator",
     "@sdkgen/parser": "file:../parser",
     "@sdkgen/playground": "file:../playground",
     "@sdkgen/typescript-generator": "file:../typescript-generator",
-    "file-type": "^14.1.2",
+    "file-type": "^14.1.3",
     "request-ip": "^2.1.3",
     "serve-handler": "^6.1.2",
     "swagger-ui-dist": "^3.25.0"

--- a/node-runtime/src/encode-decode.ts
+++ b/node-runtime/src/encode-decode.ts
@@ -1,6 +1,6 @@
+import * as CNPJ from "@fnando/cnpj";
+import * as CPF from "@fnando/cpf";
 import { AstJson, TypeDescription } from "@sdkgen/parser";
-const CPF = require("@fnando/cpf/dist/node");
-const CNPJ = require("@fnando/cnpj/dist/node");
 
 type TypeTable = AstJson["typeTable"];
 


### PR DESCRIPTION
After this `@fnando/cpf` has proper typings and can be imported with `import` rather than `require`.