### PR TITLE
Use direct references to all types, avoiding using non-existing classes

### DIFF
--- a/dart-generator/src/dart-client.ts
+++ b/dart-generator/src/dart-client.ts
@@ -1,4 +1,4 @@
-import { AstRoot } from "@sdkgen/parser";
+import { AstRoot, VoidPrimitiveType } from "@sdkgen/parser";
 import { cast, generateClass, generateEnum, generateErrorClass, generateTypeName } from "./helpers";
 
 interface Options {}
@@ -32,9 +32,9 @@ import 'package:sdkgen_runtime/http_client.dart';
 ${ast.operations
     .map(
         op => `
-  ${op.returnType.constructor.name === "VoidPrimitiveType" ? "" : `Future<${generateTypeName(op.returnType)}> `}${op.prettyName}(${
+  ${op.returnType instanceof VoidPrimitiveType ? "" : `Future<${generateTypeName(op.returnType)}> `}${op.prettyName}(${
             op.args.length === 0 ? "" : `{${op.args.map(arg => `${generateTypeName(arg.type)} ${arg.name}`).join(", ")}}`
-        }) async { ${op.returnType.constructor.name === "VoidPrimitiveType" ? "" : "return "}${cast(
+        }) async { ${op.returnType instanceof VoidPrimitiveType ? "" : "return "}${cast(
             `await makeRequest("${op.prettyName}", {${op.args.map(arg => `"${arg.name}": ${arg.name}`).join(", ")}})`,
             op.returnType,
         )}; }`,

--- a/dart-generator/src/helpers.ts
+++ b/dart-generator/src/helpers.ts
@@ -1,4 +1,30 @@
-import { ArrayType, EnumType, OptionalType, StructType, Type, TypeReference } from "@sdkgen/parser";
+import {
+    ArrayType,
+    Base64PrimitiveType,
+    BoolPrimitiveType,
+    BytesPrimitiveType,
+    CnpjPrimitiveType,
+    CpfPrimitiveType,
+    DatePrimitiveType,
+    DateTimePrimitiveType,
+    EmailPrimitiveType,
+    EnumType,
+    FloatPrimitiveType,
+    HexPrimitiveType,
+    IntPrimitiveType,
+    JsonPrimitiveType,
+    MoneyPrimitiveType,
+    OptionalType,
+    StringPrimitiveType,
+    StructType,
+    Type,
+    TypeReference,
+    UIntPrimitiveType,
+    UrlPrimitiveType,
+    UuidPrimitiveType,
+    VoidPrimitiveType,
+    XmlPrimitiveType,
+} from "@sdkgen/parser";
 
 export function generateEnum(type: EnumType) {
     return `enum ${type.name} {\n  ${type.values.map(x => x.value).join(",\n  ")}\n}\n`;
@@ -13,11 +39,11 @@ export function generateErrorClass(error: string) {
 }
 
 export function cast(value: string, type: Type): string {
-    if (type.constructor.name === "ArrayType") {
+    if (type instanceof ArrayType) {
         return `(${value} as List).map((e) => ${cast("e", (type as ArrayType).base)}).toList()`;
-    } else if (type.constructor.name === "VoidPrimitiveType") {
+    } else if (type instanceof VoidPrimitiveType) {
         return value;
-    } else if (type.constructor.name === "FloatPrimitiveType" || type.constructor.name === "MoneyPrimitiveType") {
+    } else if (type instanceof FloatPrimitiveType || type instanceof MoneyPrimitiveType) {
         return `(${value} as num)?.toDouble()`;
     } else {
         return `${value} as ${generateTypeName(type)}`;
@@ -25,45 +51,45 @@ export function cast(value: string, type: Type): string {
 }
 
 export function generateTypeName(type: Type): string {
-    switch (type.constructor.name) {
-        case "StringPrimitiveType":
+    switch (type.constructor) {
+        case StringPrimitiveType:
             return "String";
-        case "IntPrimitiveType":
-        case "UIntPrimitiveType":
+        case IntPrimitiveType:
+        case UIntPrimitiveType:
             return "int";
-        case "FloatPrimitiveType":
+        case FloatPrimitiveType:
             return "double";
-        case "DatePrimitiveType":
-        case "DateTimePrimitiveType":
+        case DatePrimitiveType:
+        case DateTimePrimitiveType:
             return "DateTime";
-        case "BoolPrimitiveType":
+        case BoolPrimitiveType:
             return "bool";
-        case "BytesPrimitiveType":
+        case BytesPrimitiveType:
             return "List<int>";
-        case "MoneyPrimitiveType":
+        case MoneyPrimitiveType:
             return "int";
-        case "CpfPrimitiveType":
-        case "CnpjPrimitiveType":
-        case "EmailPrimitiveType":
-        case "UrlPrimitiveType":
-        case "UuidPrimitiveType":
-        case "HexPrimitiveType":
-        case "Base64PrimitiveType":
-        case "XmlPrimitiveType":
+        case CpfPrimitiveType:
+        case CnpjPrimitiveType:
+        case EmailPrimitiveType:
+        case UrlPrimitiveType:
+        case UuidPrimitiveType:
+        case HexPrimitiveType:
+        case Base64PrimitiveType:
+        case XmlPrimitiveType:
             return "String";
-        case "VoidPrimitiveType":
+        case VoidPrimitiveType:
             return "void";
-        case "AnyPrimitiveType":
+        case JsonPrimitiveType:
             return "Object";
-        case "OptionalType":
+        case OptionalType:
             return generateTypeName((type as OptionalType).base);
-        case "ArrayType":
+        case ArrayType:
             return `List<${generateTypeName((type as ArrayType).base)}>`;
-        case "StructType":
+        case StructType:
             return type.name;
-        case "EnumType":
+        case EnumType:
             return type.name;
-        case "TypeReference":
+        case TypeReference:
             return generateTypeName((type as TypeReference).type);
         default:
             throw new Error(`BUG: generateTypeName with ${type.constructor.name}`);

--- a/typescript-generator/src/helpers.ts
+++ b/typescript-generator/src/helpers.ts
@@ -1,4 +1,30 @@
-import { ArrayType, EnumType, OptionalType, StructType, Type, TypeReference } from "@sdkgen/parser";
+import {
+    ArrayType,
+    Base64PrimitiveType,
+    BoolPrimitiveType,
+    BytesPrimitiveType,
+    CnpjPrimitiveType,
+    CpfPrimitiveType,
+    DatePrimitiveType,
+    DateTimePrimitiveType,
+    EmailPrimitiveType,
+    EnumType,
+    FloatPrimitiveType,
+    HexPrimitiveType,
+    IntPrimitiveType,
+    JsonPrimitiveType,
+    MoneyPrimitiveType,
+    OptionalType,
+    StringPrimitiveType,
+    StructType,
+    Type,
+    TypeReference,
+    UIntPrimitiveType,
+    UrlPrimitiveType,
+    UuidPrimitiveType,
+    VoidPrimitiveType,
+    XmlPrimitiveType,
+} from "@sdkgen/parser";
 
 export function generateTypescriptInterface(type: StructType) {
     return `export interface ${type.name} {
@@ -15,23 +41,23 @@ export function generateTypescriptErrorClass(name: string) {
 }
 
 export function clearForLogging(path: string, type: Type): string {
-    switch (type.constructor.name) {
-        case "TypeReference":
+    switch (type.constructor) {
+        case TypeReference:
             return clearForLogging(path, (type as TypeReference).type);
 
-        case "OptionalType": {
+        case OptionalType: {
             const code = clearForLogging(path, (type as OptionalType).base);
             if (code) return `if (${path} !== null && ${path} !== undefined) { ${code} }`;
             else return "";
         }
 
-        case "ArrayType": {
+        case ArrayType: {
             const code = clearForLogging("el", (type as ArrayType).base);
             if (code) return `for (const el of ${path}) { ${code} }`;
             else return "";
         }
 
-        case "StructType":
+        case StructType:
             const codes: string[] = [];
             for (const field of (type as StructType).fields) {
                 if (field.secret) {
@@ -49,55 +75,55 @@ export function clearForLogging(path: string, type: Type): string {
 }
 
 export function generateTypescriptTypeName(type: Type): string {
-    switch (type.constructor.name) {
-        case "IntPrimitiveType":
-        case "UIntPrimitiveType":
-        case "MoneyPrimitiveType":
-        case "FloatPrimitiveType":
+    switch (type.constructor) {
+        case IntPrimitiveType:
+        case UIntPrimitiveType:
+        case MoneyPrimitiveType:
+        case FloatPrimitiveType:
             return "number";
 
-        case "DatePrimitiveType":
-        case "DateTimePrimitiveType":
+        case DatePrimitiveType:
+        case DateTimePrimitiveType:
             return "Date";
 
-        case "BoolPrimitiveType":
+        case BoolPrimitiveType:
             return "boolean";
 
-        case "BytesPrimitiveType":
+        case BytesPrimitiveType:
             return "Buffer";
 
-        case "StringPrimitiveType":
-        case "CpfPrimitiveType":
-        case "CnpjPrimitiveType":
-        case "EmailPrimitiveType":
-        case "UrlPrimitiveType":
-        case "UuidPrimitiveType":
-        case "HexPrimitiveType":
-        case "Base64PrimitiveType":
-        case "XmlPrimitiveType":
+        case StringPrimitiveType:
+        case CpfPrimitiveType:
+        case CnpjPrimitiveType:
+        case EmailPrimitiveType:
+        case UrlPrimitiveType:
+        case UuidPrimitiveType:
+        case HexPrimitiveType:
+        case Base64PrimitiveType:
+        case XmlPrimitiveType:
             return "string";
 
-        case "VoidPrimitiveType":
+        case VoidPrimitiveType:
             return "void";
 
-        case "JsonPrimitiveType":
+        case JsonPrimitiveType:
             return "any";
 
-        case "OptionalType":
+        case OptionalType:
             return generateTypescriptTypeName((type as OptionalType).base) + " | null";
 
-        case "ArrayType": {
+        case ArrayType: {
             const base = (type as ArrayType).base;
             const baseGen = generateTypescriptTypeName(base);
-            if (base.constructor.name === "OptionalType") return `(${baseGen})[]`;
+            if (base instanceof OptionalType) return `(${baseGen})[]`;
             else return `${baseGen}[]`;
         }
 
-        case "StructType":
-        case "EnumType":
+        case StructType:
+        case EnumType:
             return type.name;
 
-        case "TypeReference":
+        case TypeReference:
             return generateTypescriptTypeName((type as TypeReference).type);
 
         default:


### PR DESCRIPTION
This is safe because package versions are locked to be always the same, so there won't be multiple instances of the classes from different packages.

This also fixes a wrong usage of AnyPrimitiveType in the dart generator. It was renamed to JsonPrimitiveType a while ago.