### PR TITLE
Feat: bigint type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         # TODO: Enable 13.x. See #1.
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1

--- a/browser-runtime/src/encode-decode.ts
+++ b/browser-runtime/src/encode-decode.ts
@@ -36,33 +36,21 @@ function simpleEncodeDecode(path: string, type: string, value: any) {
         }
         return value;
     } else if (type === "int") {
-        if (typeof value === "bigint") {
-            value = Number(value);
-        }
         if (typeof value !== "number" || (value | 0) !== value) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
         return value;
     } else if (type === "uint") {
-        if (typeof value === "bigint") {
-            value = Number(value);
-        }
         if (typeof value !== "number" || (value | 0) !== value || value < 0) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
         return value;
     } else if (type === "float") {
-        if (typeof value === "bigint") {
-            value = Number(value);
-        }
         if (typeof value !== "number") {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
         return value;
     } else if (type === "money") {
-        if (typeof value === "bigint") {
-            value = Number(value);
-        }
         if (typeof value !== "number" || !Number.isInteger(value)) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }

--- a/browser-runtime/src/encode-decode.ts
+++ b/browser-runtime/src/encode-decode.ts
@@ -1,12 +1,9 @@
 import { TypeDescription, TypeTable } from "./ast";
 
-const simpleStringTypes = ["string", "cep", "email", "phone", "safehtml", "xml"];
-const simpleTypes = ["json", "bool", "hex", "uuid", "base64", "url", "int", "uint", "float", "money", "void", "latlng", ...simpleStringTypes];
+const simpleStringTypes = ["string", "email", "phone", "xml"];
+const simpleTypes = ["json", "bool", "url", "int", "uint", "float", "money", "hex", "uuid", "base64", ...simpleStringTypes];
 
 function simpleEncodeDecode(path: string, type: string, value: any) {
-    if (typeof value === "bigint") {
-        value = Number(value);
-    }
     if (type === "json") {
         if (value === null || value === undefined) {
             return null;
@@ -39,21 +36,33 @@ function simpleEncodeDecode(path: string, type: string, value: any) {
         }
         return value;
     } else if (type === "int") {
+        if (typeof value === "bigint") {
+            value = Number(value);
+        }
         if (typeof value !== "number" || (value | 0) !== value) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
         return value;
     } else if (type === "uint") {
+        if (typeof value === "bigint") {
+            value = Number(value);
+        }
         if (typeof value !== "number" || (value | 0) !== value || value < 0) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
         return value;
     } else if (type === "float") {
+        if (typeof value === "bigint") {
+            value = Number(value);
+        }
         if (typeof value !== "number") {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
         return value;
     } else if (type === "money") {
+        if (typeof value === "bigint") {
+            value = Number(value);
+        }
         if (typeof value !== "number" || !Number.isInteger(value)) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
@@ -74,11 +83,6 @@ function simpleEncodeDecode(path: string, type: string, value: any) {
         return url!.toString();
     } else if (type === "void") {
         return null;
-    } else if (type === "latlng") {
-        if (typeof value !== "object" || typeof value.lat !== "number" || typeof value.lng !== "number") {
-            throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
-        }
-        return value;
     } else {
         throw new Error(`Unknown type '${type}' at '${path}'`);
     }
@@ -116,6 +120,11 @@ export function encode(typeTable: TypeTable, path: string, type: TypeDescription
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
         return value.toString("base64");
+    } else if (type === "bigint") {
+        if (!(value instanceof BigInt)) {
+            throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
+        }
+        return value.toString();
     } else if (type === "cpf") {
         if (typeof value !== "string") {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
@@ -190,6 +199,11 @@ export function decode(typeTable: TypeTable, path: string, type: TypeDescription
             throw new Error(`Invalid type at '${path}', expected ${type} (base64), got ${JSON.stringify(value)}`);
         }
         return buffer;
+    } else if (type === "bigint") {
+        if (typeof value !== "number" && (typeof value !== "string" || !value.match(/^-?[0-9]+$/))) {
+            throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
+        }
+        return BigInt(value);
     } else if (type === "cpf") {
         if (typeof value !== "string") {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);

--- a/browser-runtime/src/encode-decode.ts
+++ b/browser-runtime/src/encode-decode.ts
@@ -1,7 +1,7 @@
 import { TypeDescription, TypeTable } from "./ast";
 
 const simpleStringTypes = ["string", "email", "phone", "xml"];
-const simpleTypes = ["json", "bool", "url", "int", "uint", "float", "money", "hex", "uuid", "base64", ...simpleStringTypes];
+const simpleTypes = ["json", "bool", "url", "int", "uint", "float", "money", "hex", "uuid", "base64", "void", ...simpleStringTypes];
 
 function simpleEncodeDecode(path: string, type: string, value: any) {
     if (type === "json") {

--- a/dart-generator/src/helpers.ts
+++ b/dart-generator/src/helpers.ts
@@ -1,6 +1,7 @@
 import {
     ArrayType,
     Base64PrimitiveType,
+    BigIntPrimitiveType,
     BoolPrimitiveType,
     BytesPrimitiveType,
     CnpjPrimitiveType,
@@ -59,6 +60,8 @@ export function generateTypeName(type: Type): string {
             return "int";
         case FloatPrimitiveType:
             return "double";
+        case BigIntPrimitiveType:
+            return "BigInt";
         case DatePrimitiveType:
         case DateTimePrimitiveType:
             return "DateTime";

--- a/dart-runtime/lib/types.dart
+++ b/dart-runtime/lib/types.dart
@@ -37,29 +37,18 @@ class LatLng {
 
 const simpleStringTypes = [
   "string",
-  "cep",
   "cnpj",
   "cpf",
   "email",
   "phone",
-  "safehtml",
   "url",
-  "xml"
+  "xml",
+  "uuid",
+  "base64",
+  "hex"
 ];
-var simpleTypes = [
-      "any",
-      "bool",
-      "hex",
-      "uuid",
-      "base64",
-      "int",
-      "uint",
-      "float",
-      "money",
-      "void",
-      "latlng"
-    ] +
-    simpleStringTypes;
+var simpleTypes =
+    ["any", "bool", "int", "uint", "float", "money"] + simpleStringTypes;
 
 simpleEncodeDecode(
     Map<String, Object> typeTable, String path, Object type, Object value) {
@@ -113,6 +102,12 @@ encode(Map<String, Object> typeTable, String path, Object type, Object value) {
                 "Invalid Type at '$path', expected ${jsonEncode(type)}, got ${jsonEncode(value)}");
           }
           return Base64Encoder().convert(value);
+        case "bigint":
+          if (!(value is BigInt)) {
+            throw SdkgenTypeException(
+                "Invalid Type at '$path', expected ${jsonEncode(type)}, got ${jsonEncode(value)}");
+          }
+          return (value as BigInt).toString();
         case "date":
           if (!(value is DateTime)) {
             throw SdkgenTypeException(
@@ -189,6 +184,13 @@ decode(Map<String, Object> typeTable, String path, Object type, Object value) {
                 "Invalid Type at '$path', expected ${jsonEncode(type)}, got ${jsonEncode(value)}");
           }
           return Base64Decoder().convert(value);
+        case "bigint":
+          if (!(value is num) &&
+              (!(value is String) || !RegExp(r'^-?[0-9]+$').hasMatch(value))) {
+            throw SdkgenTypeException(
+                "Invalid Type at '$path', expected ${jsonEncode(type)}, got ${jsonEncode(value)}");
+          }
+          return value is num ? BigInt.from(value) : BigInt.parse(value);
         case "date":
           if (!(value is String) ||
               !RegExp(r'^[0-9]{4}-[01][0-9]-[0123][0-9]$').hasMatch(value)) {

--- a/node-runtime/src/encode-decode.ts
+++ b/node-runtime/src/encode-decode.ts
@@ -16,6 +16,7 @@ const simpleTypes = [
     "hex",
     "uuid",
     "base64",
+    "void",
     ...simpleStringTypes,
 ];
 

--- a/node-runtime/src/encode-decode.ts
+++ b/node-runtime/src/encode-decode.ts
@@ -61,40 +61,24 @@ function simpleEncodeDecode(path: string, type: string, value: any) {
 
         return value;
     } else if (type === "int") {
-        if (typeof value === "bigint") {
-            value = Number(value);
-        }
-
         if (typeof value !== "number" || (value | 0) !== value) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
 
         return value;
     } else if (type === "uint") {
-        if (typeof value === "bigint") {
-            value = Number(value);
-        }
-
         if (typeof value !== "number" || (value | 0) !== value || value < 0) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
 
         return value;
     } else if (type === "float") {
-        if (typeof value === "bigint") {
-            value = Number(value);
-        }
-
         if (typeof value !== "number") {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }
 
         return value;
     } else if (type === "money") {
-        if (typeof value === "bigint") {
-            value = Number(value);
-        }
-
         if (typeof value !== "number" || !Number.isInteger(value)) {
             throw new Error(`Invalid type at '${path}', expected ${type}, got ${JSON.stringify(value)}`);
         }

--- a/node-runtime/src/http-server.ts
+++ b/node-runtime/src/http-server.ts
@@ -3,6 +3,7 @@ import {
     AstJson,
     AstRoot,
     Base64PrimitiveType,
+    BigIntPrimitiveType,
     BoolPrimitiveType,
     BytesPrimitiveType,
     CnpjPrimitiveType,
@@ -294,6 +295,7 @@ export class SdkgenHttpServer<ExtraContextT = {}> {
                                             type instanceof DatePrimitiveType ||
                                             type instanceof DateTimePrimitiveType ||
                                             type instanceof MoneyPrimitiveType ||
+                                            type instanceof BigIntPrimitiveType ||
                                             type instanceof CpfPrimitiveType ||
                                             type instanceof CnpjPrimitiveType ||
                                             type instanceof UuidPrimitiveType ||
@@ -405,6 +407,7 @@ export class SdkgenHttpServer<ExtraContextT = {}> {
                                             type instanceof DatePrimitiveType ||
                                             type instanceof DateTimePrimitiveType ||
                                             type instanceof MoneyPrimitiveType ||
+                                            type instanceof BigIntPrimitiveType ||
                                             type instanceof CpfPrimitiveType ||
                                             type instanceof CnpjPrimitiveType ||
                                             type instanceof UuidPrimitiveType ||

--- a/parser/src/ast.ts
+++ b/parser/src/ast.ts
@@ -49,6 +49,9 @@ export class UIntPrimitiveType extends PrimitiveType {
 export class FloatPrimitiveType extends PrimitiveType {
     name = "float";
 }
+export class BigIntPrimitiveType extends PrimitiveType {
+    name = "bigint";
+}
 export class DatePrimitiveType extends PrimitiveType {
     name = "date";
 }

--- a/parser/src/compatibility/index.ts
+++ b/parser/src/compatibility/index.ts
@@ -2,6 +2,7 @@ import {
     ArrayType,
     AstRoot,
     Base64PrimitiveType,
+    BigIntPrimitiveType,
     BytesPrimitiveType,
     CnpjPrimitiveType,
     CpfPrimitiveType,
@@ -80,6 +81,10 @@ function checkClientToServer(path: string, issues: string[], t1: Type, t2: Type)
         (t1 instanceof IntPrimitiveType && t2 instanceof FloatPrimitiveType) ||
         (t1 instanceof MoneyPrimitiveType && t2 instanceof IntPrimitiveType) ||
         (t1 instanceof MoneyPrimitiveType && t2 instanceof UIntPrimitiveType) ||
+        (t1 instanceof UIntPrimitiveType && t2 instanceof BigIntPrimitiveType) ||
+        (t1 instanceof IntPrimitiveType && t2 instanceof BigIntPrimitiveType) ||
+        (t1 instanceof MoneyPrimitiveType && t2 instanceof BigIntPrimitiveType) ||
+        (t1 instanceof BigIntPrimitiveType && t2 instanceof StringPrimitiveType) ||
         (t1 instanceof UuidPrimitiveType && t2 instanceof StringPrimitiveType) ||
         (t1 instanceof XmlPrimitiveType && t2 instanceof StringPrimitiveType) ||
         (t1 instanceof DatePrimitiveType && t2 instanceof StringPrimitiveType) ||
@@ -166,6 +171,10 @@ function checkServerToClient(path: string, issues: string[], t1: Type, t2: Type)
         (t1 instanceof FloatPrimitiveType && t2 instanceof IntPrimitiveType) ||
         (t1 instanceof IntPrimitiveType && t2 instanceof MoneyPrimitiveType) ||
         (t1 instanceof UIntPrimitiveType && t2 instanceof MoneyPrimitiveType) ||
+        (t1 instanceof BigIntPrimitiveType && t2 instanceof UIntPrimitiveType) ||
+        (t1 instanceof BigIntPrimitiveType && t2 instanceof IntPrimitiveType) ||
+        (t1 instanceof BigIntPrimitiveType && t2 instanceof MoneyPrimitiveType) ||
+        (t1 instanceof StringPrimitiveType && t2 instanceof BigIntPrimitiveType) ||
         (t1 instanceof StringPrimitiveType && t2 instanceof UuidPrimitiveType) ||
         (t1 instanceof StringPrimitiveType && t2 instanceof XmlPrimitiveType) ||
         (t1 instanceof StringPrimitiveType && t2 instanceof DatePrimitiveType) ||

--- a/parser/src/lexer.ts
+++ b/parser/src/lexer.ts
@@ -1,4 +1,29 @@
-import { AnnotationToken, ArraySymbolToken, ColonSymbolToken, CommaSymbolToken, CurlyCloseSymbolToken, CurlyOpenSymbolToken, EnumKeywordToken, EqualSymbolToken, ErrorKeywordToken, ExclamationMarkSymbolToken, FalseKeywordToken, FunctionKeywordToken, GetKeywordToken, IdentifierToken, ImportKeywordToken, OptionalSymbolToken, ParensCloseSymbolToken, ParensOpenSymbolToken, PrimitiveTypeToken, SpreadSymbolToken, StringLiteralToken, Token, TrueKeywordToken, TypeKeywordToken } from "./token";
+import {
+    AnnotationToken,
+    ArraySymbolToken,
+    ColonSymbolToken,
+    CommaSymbolToken,
+    CurlyCloseSymbolToken,
+    CurlyOpenSymbolToken,
+    EnumKeywordToken,
+    EqualSymbolToken,
+    ErrorKeywordToken,
+    ExclamationMarkSymbolToken,
+    FalseKeywordToken,
+    FunctionKeywordToken,
+    GetKeywordToken,
+    IdentifierToken,
+    ImportKeywordToken,
+    OptionalSymbolToken,
+    ParensCloseSymbolToken,
+    ParensOpenSymbolToken,
+    PrimitiveTypeToken,
+    SpreadSymbolToken,
+    StringLiteralToken,
+    Token,
+    TrueKeywordToken,
+    TypeKeywordToken,
+} from "./token";
 
 export class LexerError extends Error {}
 

--- a/parser/src/lexer.ts
+++ b/parser/src/lexer.ts
@@ -1,29 +1,4 @@
-import {
-    AnnotationToken,
-    ArraySymbolToken,
-    ColonSymbolToken,
-    CommaSymbolToken,
-    CurlyCloseSymbolToken,
-    CurlyOpenSymbolToken,
-    EnumKeywordToken,
-    EqualSymbolToken,
-    ErrorKeywordToken,
-    ExclamationMarkSymbolToken,
-    FalseKeywordToken,
-    FunctionKeywordToken,
-    GetKeywordToken,
-    IdentifierToken,
-    ImportKeywordToken,
-    OptionalSymbolToken,
-    ParensCloseSymbolToken,
-    ParensOpenSymbolToken,
-    PrimitiveTypeToken,
-    SpreadSymbolToken,
-    StringLiteralToken,
-    Token,
-    TrueKeywordToken,
-    TypeKeywordToken,
-} from "./token";
+import { AnnotationToken, ArraySymbolToken, ColonSymbolToken, CommaSymbolToken, CurlyCloseSymbolToken, CurlyOpenSymbolToken, EnumKeywordToken, EqualSymbolToken, ErrorKeywordToken, ExclamationMarkSymbolToken, FalseKeywordToken, FunctionKeywordToken, GetKeywordToken, IdentifierToken, ImportKeywordToken, OptionalSymbolToken, ParensCloseSymbolToken, ParensOpenSymbolToken, PrimitiveTypeToken, SpreadSymbolToken, StringLiteralToken, Token, TrueKeywordToken, TypeKeywordToken } from "./token";
 
 export class LexerError extends Error {}
 
@@ -33,6 +8,7 @@ export class Lexer {
         "int",
         "uint",
         "float",
+        "bigint",
         "string",
         "date",
         "datetime",

--- a/parser/src/semantic/10_validate_annotations.ts
+++ b/parser/src/semantic/10_validate_annotations.ts
@@ -1,6 +1,7 @@
 import {
     AstNode,
     Base64PrimitiveType,
+    BigIntPrimitiveType,
     BoolPrimitiveType,
     CnpjPrimitiveType,
     CpfPrimitiveType,
@@ -30,6 +31,7 @@ const REST_ENCODABLE_TYPES: Function[] = [
     BoolPrimitiveType,
     IntPrimitiveType,
     UIntPrimitiveType,
+    BigIntPrimitiveType,
     FloatPrimitiveType,
     StringPrimitiveType,
     DatePrimitiveType,

--- a/parser/src/utils.ts
+++ b/parser/src/utils.ts
@@ -1,5 +1,6 @@
 import {
     Base64PrimitiveType,
+    BigIntPrimitiveType,
     BoolPrimitiveType,
     BytesPrimitiveType,
     CnpjPrimitiveType,
@@ -27,6 +28,7 @@ primitiveToAstClass.set("uint", UIntPrimitiveType);
 primitiveToAstClass.set("date", DatePrimitiveType);
 primitiveToAstClass.set("datetime", DateTimePrimitiveType);
 primitiveToAstClass.set("float", FloatPrimitiveType);
+primitiveToAstClass.set("bigint", BigIntPrimitiveType);
 primitiveToAstClass.set("bool", BoolPrimitiveType);
 primitiveToAstClass.set("bytes", BytesPrimitiveType);
 primitiveToAstClass.set("money", MoneyPrimitiveType);

--- a/typescript-generator/src/helpers.ts
+++ b/typescript-generator/src/helpers.ts
@@ -1,6 +1,7 @@
 import {
     ArrayType,
     Base64PrimitiveType,
+    BigIntPrimitiveType,
     BoolPrimitiveType,
     BytesPrimitiveType,
     CnpjPrimitiveType,
@@ -81,6 +82,9 @@ export function generateTypescriptTypeName(type: Type): string {
         case MoneyPrimitiveType:
         case FloatPrimitiveType:
             return "number";
+
+        case BigIntPrimitiveType:
+            return "BigInt";
 
         case DatePrimitiveType:
         case DateTimePrimitiveType:

--- a/vscode-ext/syntaxes/sdkgen.tmLanguage.json
+++ b/vscode-ext/syntaxes/sdkgen.tmLanguage.json
@@ -165,7 +165,7 @@
 					"include": "#any"
 				}, {
 					"name": "keyword.type",
-					"match": "\\b(bool|int|uint|float|string|datetime|date|bytes|void|money|cpf|cnpj|email|url|uuid|hex|base64|xml|json)\\b"
+					"match": "\\b(bool|int|uint|float|bigint|string|datetime|date|bytes|void|money|cpf|cnpj|email|url|uuid|hex|base64|xml|json)\\b"
 				}, {
 					"name": "markup.bold",
 					"match": "(\\?|\\[\\])"


### PR DESCRIPTION
BigInt type was added to all targets. With that:

1. Node 8 was dropped. It doesn't support BigInts. And also, it doesn't have official support anymore.
2. Some code about removed types still existed. Those where removed.

BigInt values are encoded as string on the json buffer. But the decoder accepts receiving an integer. So it is safe to change any `int`, `uint` or `money` types into `bigint` without breaking changes for clients.