### PR TITLE
improvement: make void functions return Future<void>

### DIFF
--- a/dart-generator/src/dart-client.ts
+++ b/dart-generator/src/dart-client.ts
@@ -32,7 +32,7 @@ import 'package:sdkgen_runtime/http_client.dart';
 ${ast.operations
     .map(
         op => `
-  ${op.returnType instanceof VoidPrimitiveType ? "" : `Future<${generateTypeName(op.returnType)}> `}${op.prettyName}(${
+  ${op.returnType instanceof VoidPrimitiveType ? "Future<void>" : `Future<${generateTypeName(op.returnType)}> `}${op.prettyName}(${
             op.args.length === 0 ? "" : `{${op.args.map(arg => `${generateTypeName(arg.type)} ${arg.name}`).join(", ")}}`
         }) async { ${op.returnType instanceof VoidPrimitiveType ? "" : "return "}${cast(
             `await makeRequest("${op.prettyName}", {${op.args.map(arg => `"${arg.name}": ${arg.name}`).join(", ")}})`,

--- a/dart-generator/src/dart-client.ts
+++ b/dart-generator/src/dart-client.ts
@@ -32,7 +32,7 @@ import 'package:sdkgen_runtime/http_client.dart';
 ${ast.operations
     .map(
         op => `
-  ${op.returnType instanceof VoidPrimitiveType ? "Future<void>" : `Future<${generateTypeName(op.returnType)}> `}${op.prettyName}(${
+  ${op.returnType instanceof VoidPrimitiveType ? "Future<void> " : `Future<${generateTypeName(op.returnType)}> `}${op.prettyName}(${
             op.args.length === 0 ? "" : `{${op.args.map(arg => `${generateTypeName(arg.type)} ${arg.name}`).join(", ")}}`
         }) async { ${op.returnType instanceof VoidPrimitiveType ? "" : "return "}${cast(
             `await makeRequest("${op.prettyName}", {${op.args.map(arg => `"${arg.name}": ${arg.name}`).join(", ")}})`,


### PR DESCRIPTION
Functions with void callback there are no typed return. The proposal of returning Future<void> allow us to make use of the object Future's methods, such as `.then()`.