### PR TITLE
fix: handle 'aborted' http response event

### DIFF
--- a/node-runtime/src/http-client.ts
+++ b/node-runtime/src/http-client.ts
@@ -71,10 +71,8 @@ export class SdkgenHttpClient {
                 res.on("error", error => {
                     reject({ message: `${error}`, type: "Fatal" });
                 });
-
                 res.on("aborted", () => {
-                  console.error("Request aborted");
-                  reject({type: "Fatal", message: "Request aborted"});
+                  reject({ message: "Request aborted", type: "Fatal" });
                 });
             });
 

--- a/node-runtime/src/http-client.ts
+++ b/node-runtime/src/http-client.ts
@@ -71,6 +71,11 @@ export class SdkgenHttpClient {
                 res.on("error", error => {
                     reject({ message: `${error}`, type: "Fatal" });
                 });
+
+                res.on("aborted", () => {
+                  console.error("Request aborted");
+                  reject({type: "Fatal", message: "Request aborted"});
+                });
             });
 
             req.on("error", error => {


### PR DESCRIPTION
http response event 'aborted' was not being captured, leading to promise not being fulfilled.