### PR TITLE
HTML type

### DIFF
--- a/browser-runtime/src/encode-decode.ts
+++ b/browser-runtime/src/encode-decode.ts
@@ -1,6 +1,6 @@
 import { TypeDescription, TypeTable } from "./ast";
 
-const simpleStringTypes = ["string", "email", "phone", "xml"];
+const simpleStringTypes = ["string", "email", "phone", "html", "xml"];
 const simpleTypes = ["json", "bool", "url", "int", "uint", "float", "money", "hex", "uuid", "base64", "void", ...simpleStringTypes];
 
 function simpleEncodeDecode(path: string, type: string, value: any) {

--- a/csharp-generator/src/helpers.ts
+++ b/csharp-generator/src/helpers.ts
@@ -12,6 +12,7 @@ import {
     EnumType,
     FloatPrimitiveType,
     HexPrimitiveType,
+    HtmlPrimitiveType,
     IntPrimitiveType,
     JsonPrimitiveType,
     MoneyPrimitiveType,
@@ -111,6 +112,7 @@ const reservedWords = [
 
 const typesWithNativeNullable: any[] = [
     StringPrimitiveType,
+    HtmlPrimitiveType,
     CpfPrimitiveType,
     CnpjPrimitiveType,
     BytesPrimitiveType,
@@ -299,6 +301,18 @@ export function decodeType(type: Type, jsonElementVar: string, path: string, tar
                 if (${jsonElementVar}.ValueKind != JsonValueKind.String)
                 {
                     throw new FatalException($"'{${path}}' must be a string.");
+                }
+                ${targetVar} = ${jsonElementVar}.GetString();
+            `
+                .replace(/\n                /g, "\n")
+                .trim();
+        }
+        case HtmlPrimitiveType: {
+            // TODO: validate HTML
+            return `
+                if (${jsonElementVar}.ValueKind != JsonValueKind.String)
+                {
+                    throw new FatalException($"'{${path}}' must be a valid HTML string.");
                 }
                 ${targetVar} = ${jsonElementVar}.GetString();
             `
@@ -566,6 +580,7 @@ export function encodeType(type: Type, valueVar: string, path: string, suffix = 
         case CpfPrimitiveType:
         case CnpjPrimitiveType:
         case EmailPrimitiveType:
+        case HtmlPrimitiveType:
         case UrlPrimitiveType:
         case UuidPrimitiveType:
         case Base64PrimitiveType:
@@ -648,6 +663,7 @@ export function generateTypeName(type: Type): string {
         case CpfPrimitiveType:
         case CnpjPrimitiveType:
         case EmailPrimitiveType:
+        case HtmlPrimitiveType:
         case UrlPrimitiveType:
         case UuidPrimitiveType:
         case HexPrimitiveType:

--- a/dart-generator/src/helpers.ts
+++ b/dart-generator/src/helpers.ts
@@ -12,6 +12,7 @@ import {
     EnumType,
     FloatPrimitiveType,
     HexPrimitiveType,
+    HtmlPrimitiveType,
     IntPrimitiveType,
     JsonPrimitiveType,
     MoneyPrimitiveType,
@@ -94,6 +95,7 @@ export function generateTypeName(type: Type): string {
         case CpfPrimitiveType:
         case CnpjPrimitiveType:
         case EmailPrimitiveType:
+        case HtmlPrimitiveType:
         case UrlPrimitiveType:
         case UuidPrimitiveType:
         case HexPrimitiveType:

--- a/dart-runtime/lib/types.dart
+++ b/dart-runtime/lib/types.dart
@@ -40,6 +40,7 @@ const simpleStringTypes = [
   "cnpj",
   "cpf",
   "email",
+  "html",
   "phone",
   "url",
   "xml",

--- a/kotlin-generator/src/helpers.ts
+++ b/kotlin-generator/src/helpers.ts
@@ -12,6 +12,7 @@ import {
     EnumType,
     FloatPrimitiveType,
     HexPrimitiveType,
+    HtmlPrimitiveType,
     IntPrimitiveType,
     JsonPrimitiveType,
     MoneyPrimitiveType,
@@ -93,6 +94,7 @@ export function generateKotlinTypeName(type: Type): string {
         case CpfPrimitiveType:
         case CnpjPrimitiveType:
         case EmailPrimitiveType:
+        case HtmlPrimitiveType:
         case UrlPrimitiveType:
         case UuidPrimitiveType:
         case HexPrimitiveType:
@@ -131,6 +133,7 @@ export function generateJsonAddRepresentation(type: Type, fieldName: string): st
         case CpfPrimitiveType:
         case CnpjPrimitiveType:
         case EmailPrimitiveType:
+        case HtmlPrimitiveType:
         case UrlPrimitiveType:
         case UuidPrimitiveType:
         case HexPrimitiveType:

--- a/node-runtime/spec/rest/api.sdkgen
+++ b/node-runtime/spec/rest/api.sdkgen
@@ -27,3 +27,6 @@ type File {
 
 @rest POST /upload
 fn uploadFile(): File[]
+
+@rest GET /html
+fn getHtml(): html

--- a/node-runtime/spec/rest/rest.spec.ts
+++ b/node-runtime/spec/rest/rest.spec.ts
@@ -49,7 +49,6 @@ api.fn.uploadFile = async (ctx: Context, args: {}) => {
     );
 };
 
-
 api.fn.getHtml = async (ctx: Context, args: {}) => {
     return "<h1>Hello world!</h1>";
 };

--- a/node-runtime/spec/rest/rest.spec.ts
+++ b/node-runtime/spec/rest/rest.spec.ts
@@ -49,6 +49,11 @@ api.fn.uploadFile = async (ctx: Context, args: {}) => {
     );
 };
 
+
+api.fn.getHtml = async (ctx: Context, args: {}) => {
+    return "<h1>Hello world!</h1>";
+};
+
 writeFileSync(
     `${__dirname}/nodeClient.ts`,
     generateNodeClientSource(ast, {}).replace("@sdkgen/node-runtime", "../../src"),
@@ -254,6 +259,14 @@ describe("Rest API", () => {
             statusCode: 200,
             resultHeaders: {
                 "content-type": "application/json",
+            },
+        },
+        {
+            method: "GET",
+            path: "/html",
+            result: "<h1>Hello world!</h1>",
+            resultHeaders: {
+                "content-type": "text/html",
             },
         },
         (() => {

--- a/node-runtime/src/encode-decode.ts
+++ b/node-runtime/src/encode-decode.ts
@@ -4,7 +4,7 @@ import { AstJson, TypeDescription } from "@sdkgen/parser";
 
 type TypeTable = AstJson["typeTable"];
 
-const simpleStringTypes = ["string", "email", "xml"];
+const simpleStringTypes = ["string", "email", "html", "xml"];
 const simpleTypes = [
     "json",
     "bool",

--- a/node-runtime/src/http-server.ts
+++ b/node-runtime/src/http-server.ts
@@ -12,6 +12,7 @@ import {
     DateTimePrimitiveType,
     FloatPrimitiveType,
     HexPrimitiveType,
+    HtmlPrimitiveType,
     IntPrimitiveType,
     jsonToAst,
     MoneyPrimitiveType,
@@ -354,6 +355,7 @@ export class SdkgenHttpServer<ExtraContextT = {}> {
                                             type instanceof BigIntPrimitiveType ||
                                             type instanceof CpfPrimitiveType ||
                                             type instanceof CnpjPrimitiveType ||
+                                            type instanceof HtmlPrimitiveType ||
                                             type instanceof UuidPrimitiveType ||
                                             type instanceof HexPrimitiveType ||
                                             type instanceof Base64PrimitiveType
@@ -468,11 +470,16 @@ export class SdkgenHttpServer<ExtraContextT = {}> {
                                             type instanceof BigIntPrimitiveType ||
                                             type instanceof CpfPrimitiveType ||
                                             type instanceof CnpjPrimitiveType ||
+                                            type instanceof HtmlPrimitiveType ||
                                             type instanceof UuidPrimitiveType ||
                                             type instanceof HexPrimitiveType ||
                                             type instanceof Base64PrimitiveType
                                         ) {
                                             res.setHeader("content-type", "text/plain");
+                                            res.write(`${reply.result}`);
+                                            res.end();
+                                        } else if (type instanceof HtmlPrimitiveType) {
+                                            res.setHeader("content-type", "text/html");
                                             res.write(`${reply.result}`);
                                             res.end();
                                         } else if (type instanceof BytesPrimitiveType) {

--- a/node-runtime/src/http-server.ts
+++ b/node-runtime/src/http-server.ts
@@ -355,7 +355,6 @@ export class SdkgenHttpServer<ExtraContextT = {}> {
                                             type instanceof BigIntPrimitiveType ||
                                             type instanceof CpfPrimitiveType ||
                                             type instanceof CnpjPrimitiveType ||
-                                            type instanceof HtmlPrimitiveType ||
                                             type instanceof UuidPrimitiveType ||
                                             type instanceof HexPrimitiveType ||
                                             type instanceof Base64PrimitiveType

--- a/node-runtime/src/http-server.ts
+++ b/node-runtime/src/http-server.ts
@@ -470,7 +470,6 @@ export class SdkgenHttpServer<ExtraContextT = {}> {
                                             type instanceof BigIntPrimitiveType ||
                                             type instanceof CpfPrimitiveType ||
                                             type instanceof CnpjPrimitiveType ||
-                                            type instanceof HtmlPrimitiveType ||
                                             type instanceof UuidPrimitiveType ||
                                             type instanceof HexPrimitiveType ||
                                             type instanceof Base64PrimitiveType

--- a/node-runtime/src/swagger.ts
+++ b/node-runtime/src/swagger.ts
@@ -11,6 +11,7 @@ import {
     EnumType,
     FloatPrimitiveType,
     HexPrimitiveType,
+    HtmlPrimitiveType,
     IntPrimitiveType,
     MoneyPrimitiveType,
     OptionalType,
@@ -198,12 +199,17 @@ export function setupSwagger<ExtraContextT>(server: SdkgenHttpServer<ExtraContex
                                                   bodyType instanceof MoneyPrimitiveType ||
                                                   bodyType instanceof CpfPrimitiveType ||
                                                   bodyType instanceof CnpjPrimitiveType ||
+                                                  bodyType instanceof HtmlPrimitiveType ||
                                                   bodyType instanceof UuidPrimitiveType ||
                                                   bodyType instanceof HexPrimitiveType ||
                                                   bodyType instanceof BytesPrimitiveType ||
                                                   bodyType instanceof Base64PrimitiveType
                                                   ? {
-                                                        "text/plain": { schema: typeToSchema(definitions, bodyType) },
+                                                        [bodyType instanceof HtmlPrimitiveType
+                                                            ? "text/html"
+                                                            : "text/plain"]: {
+                                                            schema: typeToSchema(definitions, bodyType),
+                                                        },
                                                     }
                                                   : {};
                                           })(),
@@ -331,6 +337,7 @@ function typeToSchema(definitions: any, type: Type): any {
         type instanceof StringPrimitiveType ||
         type instanceof UuidPrimitiveType ||
         type instanceof HexPrimitiveType ||
+        type instanceof HtmlPrimitiveType ||
         type instanceof Base64PrimitiveType
     ) {
         return {

--- a/parser/src/ast.ts
+++ b/parser/src/ast.ts
@@ -88,6 +88,9 @@ export class UuidPrimitiveType extends PrimitiveType {
 export class HexPrimitiveType extends PrimitiveType {
     name = "hex";
 }
+export class HtmlPrimitiveType extends PrimitiveType {
+    name = "html";
+}
 export class Base64PrimitiveType extends PrimitiveType {
     name = "base64";
 }

--- a/parser/src/compatibility/index.ts
+++ b/parser/src/compatibility/index.ts
@@ -12,6 +12,7 @@ import {
     EnumType,
     FloatPrimitiveType,
     HexPrimitiveType,
+    HtmlPrimitiveType,
     IntPrimitiveType,
     MoneyPrimitiveType,
     OptionalType,
@@ -92,6 +93,7 @@ function checkClientToServer(path: string, issues: string[], t1: Type, t2: Type)
         (t1 instanceof CpfPrimitiveType && t2 instanceof StringPrimitiveType) ||
         (t1 instanceof CnpjPrimitiveType && t2 instanceof StringPrimitiveType) ||
         (t1 instanceof HexPrimitiveType && t2 instanceof StringPrimitiveType) ||
+        (t1 instanceof HtmlPrimitiveType && t2 instanceof StringPrimitiveType) ||
         (t1 instanceof Base64PrimitiveType && t2 instanceof StringPrimitiveType) ||
         (t1 instanceof BytesPrimitiveType && t2 instanceof StringPrimitiveType) ||
         (t1 instanceof BytesPrimitiveType && t2 instanceof Base64PrimitiveType) ||
@@ -182,6 +184,7 @@ function checkServerToClient(path: string, issues: string[], t1: Type, t2: Type)
         (t1 instanceof StringPrimitiveType && t2 instanceof CpfPrimitiveType) ||
         (t1 instanceof StringPrimitiveType && t2 instanceof CnpjPrimitiveType) ||
         (t1 instanceof StringPrimitiveType && t2 instanceof HexPrimitiveType) ||
+        (t1 instanceof StringPrimitiveType && t2 instanceof HtmlPrimitiveType) ||
         (t1 instanceof StringPrimitiveType && t2 instanceof Base64PrimitiveType) ||
         (t1 instanceof StringPrimitiveType && t2 instanceof BytesPrimitiveType) ||
         (t1 instanceof Base64PrimitiveType && t2 instanceof BytesPrimitiveType) ||

--- a/parser/src/lexer.ts
+++ b/parser/src/lexer.ts
@@ -42,6 +42,7 @@ export class Lexer {
         "cpf",
         "cnpj",
         "email",
+        "html",
         "url",
         "uuid",
         "hex",

--- a/parser/src/semantic/10_validate_annotations.ts
+++ b/parser/src/semantic/10_validate_annotations.ts
@@ -13,7 +13,6 @@ import {
     Field,
     FloatPrimitiveType,
     HexPrimitiveType,
-    HtmlPrimitiveType,
     IntPrimitiveType,
     MoneyPrimitiveType,
     Operation,
@@ -45,7 +44,6 @@ const REST_ENCODABLE_TYPES: Function[] = [
     CnpjPrimitiveType,
     UuidPrimitiveType,
     HexPrimitiveType,
-    HtmlPrimitiveType,
     Base64PrimitiveType,
     EnumType,
 ];

--- a/parser/src/semantic/10_validate_annotations.ts
+++ b/parser/src/semantic/10_validate_annotations.ts
@@ -13,6 +13,7 @@ import {
     Field,
     FloatPrimitiveType,
     HexPrimitiveType,
+    HtmlPrimitiveType,
     IntPrimitiveType,
     MoneyPrimitiveType,
     Operation,
@@ -44,6 +45,7 @@ const REST_ENCODABLE_TYPES: Function[] = [
     CnpjPrimitiveType,
     UuidPrimitiveType,
     HexPrimitiveType,
+    HtmlPrimitiveType,
     Base64PrimitiveType,
     EnumType,
 ];

--- a/parser/src/utils.ts
+++ b/parser/src/utils.ts
@@ -10,6 +10,7 @@ import {
     EmailPrimitiveType,
     FloatPrimitiveType,
     HexPrimitiveType,
+    HtmlPrimitiveType,
     IntPrimitiveType,
     JsonPrimitiveType,
     MoneyPrimitiveType,
@@ -35,6 +36,7 @@ primitiveToAstClass.set("money", MoneyPrimitiveType);
 primitiveToAstClass.set("cpf", CpfPrimitiveType);
 primitiveToAstClass.set("cnpj", CnpjPrimitiveType);
 primitiveToAstClass.set("email", EmailPrimitiveType);
+primitiveToAstClass.set("html", HtmlPrimitiveType);
 primitiveToAstClass.set("url", UrlPrimitiveType);
 primitiveToAstClass.set("uuid", UuidPrimitiveType);
 primitiveToAstClass.set("hex", HexPrimitiveType);

--- a/playground/src/stores/requests.ts
+++ b/playground/src/stores/requests.ts
@@ -10,8 +10,8 @@ export const simpleStringTypes = [
 	"cnpj",
 	"cpf",
 	"email",
+	"html",
 	"phone",
-	"safehtml",
 	"url",
 	"xml",
 ];

--- a/typescript-generator/src/helpers.ts
+++ b/typescript-generator/src/helpers.ts
@@ -12,6 +12,7 @@ import {
     EnumType,
     FloatPrimitiveType,
     HexPrimitiveType,
+    HtmlPrimitiveType,
     IntPrimitiveType,
     JsonPrimitiveType,
     MoneyPrimitiveType,
@@ -100,6 +101,7 @@ export function generateTypescriptTypeName(type: Type): string {
         case CpfPrimitiveType:
         case CnpjPrimitiveType:
         case EmailPrimitiveType:
+        case HtmlPrimitiveType:
         case UrlPrimitiveType:
         case UuidPrimitiveType:
         case HexPrimitiveType:

--- a/vscode-ext/syntaxes/sdkgen.tmLanguage.json
+++ b/vscode-ext/syntaxes/sdkgen.tmLanguage.json
@@ -165,7 +165,7 @@
 					"include": "#any"
 				}, {
 					"name": "keyword.type",
-					"match": "\\b(bool|int|uint|float|bigint|string|datetime|date|bytes|void|money|cpf|cnpj|email|url|uuid|hex|base64|xml|json)\\b"
+					"match": "\\b(bool|int|uint|float|bigint|string|datetime|date|bytes|void|money|cpf|cnpj|email|html|url|uuid|hex|base64|xml|json)\\b"
 				}, {
 					"name": "markup.bold",
 					"match": "(\\?|\\[\\])"


### PR DESCRIPTION
Adds an `html` type that, on Rest requests, acts as string and correctly sends responses as `text/html` instead of `text/plain`.