### PR TITLE
node client extra property was not being sent to server

### DIFF
--- a/node-runtime/src/http-client.ts
+++ b/node-runtime/src/http-client.ts
@@ -32,7 +32,7 @@ export class SdkgenHttpClient {
             args: encode(this.astJson.typeTable, `${functionName}.args`, func.args, args),
             deviceInfo: ctx && ctx.request ? ctx.request.deviceInfo : { id: hostname(), type: "node" },
             extra: {
-                ...this.extra,
+                ...[...this.extra.entries()].reduce<{ [key: string]: unknown }>((obj, [key, value]) => (obj[key] = value, obj), {}),
                 ...(ctx && ctx.request ? ctx.request.extra : {}),
             },
             name: functionName,


### PR DESCRIPTION
Code was destructuring a Map, causing it to return an empty object and thus not sending mapped values to server. Added the shortest one-liner to turn a map into an object in ES6 I could find.