### PR TITLE
Use bigint type name for typescript instead of BigInt

### DIFF
--- a/node-runtime/spec/types.spec.ts
+++ b/node-runtime/spec/types.spec.ts
@@ -86,9 +86,13 @@ describe("Encode/Decode", () => {
             encode({}, "", "datetime", "2020-11-10T15:34:50.999$01:00");
         }).toThrow();
         expect(() => {
-          decode({}, "", "datetime", "2020-11-10T15:34:50.999$01:00");
+            decode({}, "", "datetime", "2020-11-10T15:34:50.999$01:00");
         }).toThrow();
-        expect(decode({}, "", "datetime", "2020-11-10T15:34:50Z").getTime()).toBe(new Date("2020-11-10T15:34:50Z").getTime());
-        expect(decode({}, "", "datetime", "2020-11-10T15:34:50.000").getTime()).toBe(new Date("2020-11-10T15:34:50Z").getTime());
+        expect(decode({}, "", "datetime", "2020-11-10T15:34:50Z").getTime()).toBe(
+            new Date("2020-11-10T15:34:50Z").getTime(),
+        );
+        expect(decode({}, "", "datetime", "2020-11-10T15:34:50.000").getTime()).toBe(
+            new Date("2020-11-10T15:34:50Z").getTime(),
+        );
     });
 });

--- a/typescript-generator/spec/helpers.spec.ts
+++ b/typescript-generator/spec/helpers.spec.ts
@@ -1,0 +1,150 @@
+import { generateTypescriptInterface, generateTypescriptTypeName } from "../src/helpers";
+import * as parser from "@sdkgen/parser";
+
+describe("helpers.ts", () => {
+    test("generateTypescriptInterface", () => {
+
+        const structType = new parser.StructType(
+            [
+                new parser.Field("int", new parser.IntPrimitiveType()),
+                new parser.Field("bigint", new parser.BigIntPrimitiveType()),
+                new parser.Field("date", new parser.DatePrimitiveType()),
+                new parser.Field("bool", new parser.BoolPrimitiveType()),
+                new parser.Field("bytes", new parser.BytesPrimitiveType()),
+                new parser.Field("uuid", new parser.UuidPrimitiveType()),
+                new parser.Field("void", new parser.VoidPrimitiveType()),
+                new parser.Field("json", new parser.JsonPrimitiveType()),
+                new parser.Field("optionalStrArray", new parser.OptionalType(
+                    new parser.ArrayType(
+                        new parser.StringPrimitiveType()
+                    )
+                )),
+            ],
+            []
+        )
+        structType.name = "awesomeInterface";
+
+        expect(generateTypescriptInterface(structType)).toBe(`export interface awesomeInterface {
+    int: number
+    bigint: bigint
+    date: Date
+    bool: boolean
+    bytes: Buffer
+    uuid: string
+    void: void
+    json: any
+    optionalStrArray: string[] | null
+}
+`
+        );
+    });
+
+    test("generateTypescriptTypeName: IntPrimitiveType", () => {
+        const type = new parser.IntPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("number");
+    });
+
+    test("generateTypescriptTypeName: UIntPrimitiveType", () => {
+        const type = new parser.UIntPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("number");
+    });
+
+    test("generateTypescriptTypeName: MoneyPrimitiveType", () => {
+        const type = new parser.MoneyPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("number");
+    });
+
+    test("generateTypescriptTypeName: FloatPrimitiveType", () => {
+        const type = new parser.FloatPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("number");
+    });
+
+    test("generateTypescriptTypeName: DateTimePrimitiveType", () => {
+        const type = new parser.DateTimePrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("Date");
+    });
+
+    test("generateTypescriptTypeName: StringPrimitiveType", () => {
+        const type = new parser.StringPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("string");
+    });
+
+    test("generateTypescriptTypeName: CpfPrimitiveType", () => {
+        const type = new parser.CpfPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("string");
+    });
+
+    test("generateTypescriptTypeName: CnpjPrimitiveType", () => {
+        const type = new parser.CnpjPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("string");
+    });
+
+    test("generateTypescriptTypeName: EmailPrimitiveType", () => {
+        const type = new parser.EmailPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("string");
+    });
+
+    test("generateTypescriptTypeName: HtmlPrimitiveType", () => {
+        const type = new parser.HtmlPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("string");
+    });
+
+    test("generateTypescriptTypeName: UrlPrimitiveType", () => {
+        const type = new parser.UrlPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("string");
+    });
+
+    test("generateTypescriptTypeName: HexPrimitiveType", () => {
+        const type = new parser.HexPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("string");
+    });
+
+    test("generateTypescriptTypeName: Base64PrimitiveType", () => {
+        const type = new parser.Base64PrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("string");
+    });
+
+    test("generateTypescriptTypeName: XmlPrimitiveType", () => {
+        const type = new parser.XmlPrimitiveType();
+        expect(generateTypescriptTypeName(type)).toBe("string");
+    });
+
+    test("generateTypescriptTypeName: StructType", () => {
+        const structType = new parser.StructType(
+            [
+                new parser.Field("int", new parser.IntPrimitiveType()),
+                new parser.Field("bigint", new parser.BigIntPrimitiveType()),
+            ],
+            []
+        )
+        structType.name = "simpleInterface";
+        expect(generateTypescriptTypeName(structType)).toBe(structType.name);
+    });
+
+    test("generateTypescriptTypeName: EnumType", () => {
+        const enumType = new parser.EnumType(
+            [new parser.EnumValue("value1")],
+        );
+
+        enumType.name = "simpleEnum";
+
+        expect(generateTypescriptTypeName(enumType)).toBe(enumType.name);
+    });
+
+    test("generateTypescriptTypeName: TypeReference", () => {
+        const enumType = new parser.TypeReference("typeRef")
+        enumType.type = new parser.HexPrimitiveType();
+
+        expect(generateTypescriptTypeName(enumType)).toBe("string");
+    });
+
+    test("generateTypescriptTypeName: unknown PrimitiveType error", () => {
+        class UnknownType extends parser.Type {
+            name = "UnknownType";
+        }
+
+        const newUnknownType = new UnknownType();
+
+        expect(() => generateTypescriptTypeName(newUnknownType)).toThrowError(`BUG: generateTypescriptTypeName with ${newUnknownType.name}`)
+    })
+})

--- a/typescript-generator/spec/helpers.spec.ts
+++ b/typescript-generator/spec/helpers.spec.ts
@@ -3,7 +3,6 @@ import * as parser from "@sdkgen/parser";
 
 describe("helpers.ts", () => {
     test("generateTypescriptInterface", () => {
-
         const structType = new parser.StructType(
             [
                 new parser.Field("int", new parser.IntPrimitiveType()),
@@ -14,14 +13,10 @@ describe("helpers.ts", () => {
                 new parser.Field("uuid", new parser.UuidPrimitiveType()),
                 new parser.Field("void", new parser.VoidPrimitiveType()),
                 new parser.Field("json", new parser.JsonPrimitiveType()),
-                new parser.Field("optionalStrArray", new parser.OptionalType(
-                    new parser.ArrayType(
-                        new parser.StringPrimitiveType()
-                    )
-                )),
+                new parser.Field("optionalStrArray", new parser.OptionalType(new parser.ArrayType(new parser.StringPrimitiveType()))),
             ],
-            []
-        )
+            [],
+        );
         structType.name = "awesomeInterface";
 
         expect(generateTypescriptInterface(structType)).toBe(`export interface awesomeInterface {
@@ -35,8 +30,7 @@ describe("helpers.ts", () => {
     json: any
     optionalStrArray: string[] | null
 }
-`
-        );
+`);
     });
 
     test("generateTypescriptTypeName: IntPrimitiveType", () => {
@@ -111,20 +105,15 @@ describe("helpers.ts", () => {
 
     test("generateTypescriptTypeName: StructType", () => {
         const structType = new parser.StructType(
-            [
-                new parser.Field("int", new parser.IntPrimitiveType()),
-                new parser.Field("bigint", new parser.BigIntPrimitiveType()),
-            ],
-            []
-        )
+            [new parser.Field("int", new parser.IntPrimitiveType()), new parser.Field("bigint", new parser.BigIntPrimitiveType())],
+            [],
+        );
         structType.name = "simpleInterface";
         expect(generateTypescriptTypeName(structType)).toBe(structType.name);
     });
 
     test("generateTypescriptTypeName: EnumType", () => {
-        const enumType = new parser.EnumType(
-            [new parser.EnumValue("value1")],
-        );
+        const enumType = new parser.EnumType([new parser.EnumValue("value1")]);
 
         enumType.name = "simpleEnum";
 
@@ -132,7 +121,7 @@ describe("helpers.ts", () => {
     });
 
     test("generateTypescriptTypeName: TypeReference", () => {
-        const enumType = new parser.TypeReference("typeRef")
+        const enumType = new parser.TypeReference("typeRef");
         enumType.type = new parser.HexPrimitiveType();
 
         expect(generateTypescriptTypeName(enumType)).toBe("string");
@@ -145,6 +134,6 @@ describe("helpers.ts", () => {
 
         const newUnknownType = new UnknownType();
 
-        expect(() => generateTypescriptTypeName(newUnknownType)).toThrowError(`BUG: generateTypescriptTypeName with ${newUnknownType.name}`)
-    })
-})
+        expect(() => generateTypescriptTypeName(newUnknownType)).toThrowError(`BUG: generateTypescriptTypeName with ${newUnknownType.name}`);
+    });
+});

--- a/typescript-generator/src/helpers.ts
+++ b/typescript-generator/src/helpers.ts
@@ -85,7 +85,7 @@ export function generateTypescriptTypeName(type: Type): string {
             return "number";
 
         case BigIntPrimitiveType:
-            return "BigInt";
+            return "bigint";
 
         case DatePrimitiveType:
         case DateTimePrimitiveType:


### PR DESCRIPTION
The current correct type usage for javascript BigInt in Typescript is `bigint`.

Reference: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html#bigint