### PR TITLE
[Dart] fix: Add named parameters to the classes constructors on StructTypeDescription

### DIFF
--- a/dart-generator/src/dart-client.ts
+++ b/dart-generator/src/dart-client.ts
@@ -45,19 +45,24 @@ ${ast.operations
     code += `var _typeTable = {\n`;
 
     for (const type of ast.structTypes) {
-        code += `  "${type.name}": StructTypeDescription(${type.name}, {\n`;
+        code += `  "${type.name}": StructTypeDescription(\n`;
+        code += `    ${type.name},\n`;
+        code += `    {\n`;
         for (const field of type.fields) {
-            code += `    "${field.name}": "${field.type.name}",\n`;
+            code += `      "${field.name}": "${field.type.name}",\n`;
         }
-        code += `  }, (Map fields) => ${type.name}()\n`;
+        code += `    },\n`;
+        code += `    (Map fields) => ${type.name}(\n`;
         for (const field of type.fields) {
-            code += `    ..${field.name} = ${cast(`fields["${field.name}"]`, field.type)}\n`;
+            code += `      ${field.name}: ${cast(`fields["${field.name}"]`, field.type)},\n`;
         }
-        code += `  , (${type.name} obj) => ({\n`;
+        code += `    ),\n`;
+        code += `    (${type.name} obj) => ({\n`;
         for (const field of type.fields) {
-            code += `    "${field.name}": obj.${field.name},\n`;
+            code += `      "${field.name}": obj.${field.name},\n`;
         }
-        code += "  })),\n";
+        code += `    }),\n`;
+        code += `  ),\n`;
     }
 
     for (const type of ast.enumTypes) {


### PR DESCRIPTION
The way to declare a Dart class instance changed when the class constructors with @required tags were applied.

The old way:

```
(Map fields) => MyClass()
  ..id = fields["id"] as String
  ..name = fields["name"] as String,
```

The new way:
```
(Map fields) => MyClass(
  id: fields["id"] as String,
  name: fields["name"] as String
),
```

This pull request applies this fix, solving the warnings from the `client.dart` file.

ATTENTION: Further tests are required!