### PR TITLE
instructions for other developers

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -1,2 +1,62 @@
 # @sdkgen/playground
 
+The default web playground for sdkgen APIs, allowing easy interaction with deployed or local servers.
+
+# How to use
+
+just open a web browser on https://yourApiEndpoint.com/playground
+
+# Features
+
+- list all possbible endpoints
+- search endpoints
+- make requests
+- set a custom device id
+- copy retuned values to clipboard
+- display endpoint annotations
+
+
+# Development 
+
+## Install dependecies 
+```
+npm i 
+```
+
+## Running locally
+```
+npm run dev
+```
+a local version of the playground will be avaliable on http://localhost:4545/playground/ 
+
+by the default the playground will make requests to http://localhost:8000/, it's recomended to run an local sdkgen server alongside the playground dev server, here is an example of [very simple sdkgen server](https://github.com/kevinoliveira/sdkgen-helloworld) that you can use to develop.
+ 
+
+## Checking for type errors
+```
+npm run check
+```
+
+## Runing tests
+run all tests
+```
+npm run test
+```
+run all tests watching for file changes
+```
+npm run test:w
+```
+run a test file watching for file changes
+```
+npm run test:w playground/example.test.tsx
+```
+
+## Linting
+```
+npm run lint
+```
+
+## Building
+```
+npm run build
+```

--- a/playground/README.md
+++ b/playground/README.md
@@ -4,7 +4,7 @@ The default web playground for sdkgen APIs, allowing easy interaction with deplo
 
 # How to use
 
-just open a web browser on https://yourApiEndpoint.com/playground
+Just open a web browser on https://yourApiEndpoint.com/playground
 
 # Features
 
@@ -29,7 +29,7 @@ npm run dev
 ```
 a local version of the playground will be avaliable on http://localhost:4545/playground/ 
 
-by the default the playground will make requests to http://localhost:8000/, it's recomended to run an local sdkgen server alongside the playground dev server, here is an example of [very simple sdkgen server](https://github.com/kevinoliveira/sdkgen-helloworld) that you can use to develop.
+by default the playground will make requests to http://localhost:8000/, it's recomended to run an local sdkgen server alongside the playground dev server, here is an example of [very simple sdkgen server](https://github.com/kevinoliveira/sdkgen-helloworld) that you can use to develop.
  
 
 ## Checking for type errors


### PR DESCRIPTION
improvments made on readme to help other developers get started, instructions were added on how to run the development server, run a api server alongside, run tests, check for type errors and linting