### PR TITLE
fix error display message container

### DIFF
--- a/playground/src/components/requestCard/errors/errors.scss
+++ b/playground/src/components/requestCard/errors/errors.scss
@@ -4,3 +4,8 @@
 	justify-content: center;
 	padding: 20px;
 }
+
+.pre {
+	white-space: pre-wrap;
+	margin: 10px;
+}

--- a/playground/src/components/requestCard/errors/index.tsx
+++ b/playground/src/components/requestCard/errors/index.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export function Errors(props: Props) {
 	return props.error ? (
-		<pre>{props.error}</pre>
+		<pre className={s.pre}>{props.error}</pre>
 	) : (
 		<div className={s.empty}>There is no errors</div>
 	);


### PR DESCRIPTION
this fix stops the error message to overflow the card container, the error affect specially mobile users because they lack a larger screen.


### screenshots
![2020-10-04_01-30](https://user-images.githubusercontent.com/14365975/95007128-82caab00-05e2-11eb-9b87-069281a61290.png)
![2020-10-04_01-31](https://user-images.githubusercontent.com/14365975/95007131-852d0500-05e2-11eb-9381-26af734b6c8d.png)
