### PR TITLE
Fix error type overwrite

### DIFF
--- a/node-runtime/src/error.ts
+++ b/node-runtime/src/error.ts
@@ -6,7 +6,7 @@ export class SdkgenError extends Error {
     public toJSON() {
         return {
             message: this.message,
-            type: this.constructor.name,
+            type: this.type,
         };
     }
 }

--- a/node-runtime/src/http-server.ts
+++ b/node-runtime/src/http-server.ts
@@ -726,7 +726,7 @@ export class SdkgenHttpServer<ExtraContextT = {}> {
 
                 if (allowedErrors.length > 0) {
                     if (!allowedErrors.includes(reply.error.type)) {
-                        reply.error.type = "Fatal";
+                        Object.defineProperty(reply.error, "type", { value: "Fatal" });
                     }
                 }
             }


### PR DESCRIPTION
When throwing an error in a function defined with `@throws` annotation, [sdkgen checks if the error type matches any of the error types specified in `@throws`, and if it doesn't, the type is replaced with Fatal](https://github.com/sdkgen/sdkgen/blob/a7348d82d35ccfdbe349453aa6a829de4f961c23/node-runtime/src/http-server.ts#L718-L733).

The problem is, if you throw an SdkgenError, [whose `type` doesn't have an setter](https://github.com/sdkgen/sdkgen/blob/a7348d82d35ccfdbe349453aa6a829de4f961c23/node-runtime/src/error.ts#L2-L4), it'll end in an unhandled rejection:

```
(node:1) UnhandledPromiseRejectionWarning: TypeError: Cannot set property type of Error which has only a getter
    at SdkgenHttpServer.executeRequest (/app/node_modules/@sdkgen/node-runtime/dist/src/http-server.js:574:42)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

This fix changes SdkgenError's `toJSON` to use the internal property `type` (instead of using the same way it gets its value) and overwrites its value using `Object.defineProperty`.
