### PR TITLE
feat: implement "hidden" annotation

### DIFF
--- a/dart-generator/src/dart-client.ts
+++ b/dart-generator/src/dart-client.ts
@@ -1,4 +1,4 @@
-import { AstRoot, VoidPrimitiveType } from "@sdkgen/parser";
+import { AstRoot, HiddenAnnotation, VoidPrimitiveType } from "@sdkgen/parser";
 import { cast, generateClass, generateEnum, generateErrorClass, generateTypeName } from "./helpers";
 
 export function generateDartClientSource(ast: AstRoot): string {
@@ -28,6 +28,7 @@ import 'package:sdkgen_runtime/http_client.dart';
   code += `class ApiClient extends SdkgenHttpClient {
   ApiClient(String baseUrl, [BuildContext context]) : super(baseUrl, context, _typeTable, _fnTable, _errTable);
 ${ast.operations
+  .filter(op => op.annotations.every(ann => !(ann instanceof HiddenAnnotation)))
   .map(
     op => `
   ${op.returnType instanceof VoidPrimitiveType ? "Future<void> " : `Future<${generateTypeName(op.returnType)}> `}${op.prettyName}(${

--- a/kotlin-generator/src/android-client.ts
+++ b/kotlin-generator/src/android-client.ts
@@ -1,4 +1,4 @@
-import { AstRoot } from "@sdkgen/parser";
+import { AstRoot, HiddenAnnotation } from "@sdkgen/parser";
 import { generateClass, generateEnum, generateErrorClass, generateJsonAddRepresentation, generateKotlinTypeName, mangle } from "./helpers";
 
 export function generateAndroidClientSource(ast: AstRoot): string {
@@ -74,6 +74,7 @@ class ApiClient(
 
   code += `    private val sdkgenIOScope = CoroutineScope(IO)\n\n`;
   code += ast.operations
+    .filter(op => op.annotations.every(ann => !(ann instanceof HiddenAnnotation)))
     .map(op => {
       let opImpl = "";
       const args = op.args

--- a/parser/spec/parser.spec.ts
+++ b/parser/spec/parser.spec.ts
@@ -22,10 +22,10 @@ describe(Parser, () => {
     test(`handles primitive type '${p}'`, () => {
       expectParses(
         `
-                    type Foo {
-                        foo: ${p}
-                    }
-                `,
+          type Foo {
+            foo: ${p}
+          }
+        `,
         {
           annotations: {},
           errors: ["Fatal"],
@@ -42,10 +42,10 @@ describe(Parser, () => {
     test(`handles simple get operations for primitive type '${p}'`, () => {
       expectParses(
         `
-                    get ${p === "bool" ? "isFoo" : "foo"}(): ${p}
-                    get bar(): ${p}?
-                    fn getBaz(): ${p}[]
-                `,
+          get ${p === "bool" ? "isFoo" : "foo"}(): ${p}
+          get bar(): ${p}?
+          fn getBaz(): ${p}[]
+        `,
         {
           annotations: {},
           errors: ["Fatal"],
@@ -65,7 +65,7 @@ describe(Parser, () => {
           },
           typeTable: {},
         },
-        ["Keyword 'get' is deprecated at -:2:21. Use 'fn' instead.", "Keyword 'get' is deprecated at -:3:21. Use 'fn' instead."],
+        ["Keyword 'get' is deprecated at -:2:11. Use 'fn' instead.", "Keyword 'get' is deprecated at -:3:11. Use 'fn' instead."],
       );
     });
   }
@@ -74,10 +74,10 @@ describe(Parser, () => {
     test(`handles '${kw}' on the name of a field`, () => {
       expectParses(
         `
-                type Foo {
-                    ${kw}: int
-                }
-                `,
+          type Foo {
+            ${kw}: int
+          }
+        `,
         {
           annotations: {},
           errors: ["Fatal"],
@@ -95,13 +95,13 @@ describe(Parser, () => {
   test("handles arrays and optionals", () => {
     expectParses(
       `
-                type Foo {
-                    aa: string[]
-                    bbb: int?[]??
-                    cccc: int[][][]
-                    ddddd: uint[][][]??[]???[][]
-                }
-            `,
+        type Foo {
+          aa: string[]
+          bbb: int?[]??
+          cccc: int[][][]
+          ddddd: uint[][][]??[]???[][]
+        }
+      `,
       {
         annotations: {},
         errors: ["Fatal"],
@@ -121,15 +121,15 @@ describe(Parser, () => {
   test("handles enums", () => {
     expectParses(
       `
-                type Foo {
-                    a: int
-                    status: enum {
-                        c a zzz
-                    }
-                }
+        type Foo {
+          a: int
+          status: enum {
+            c a zzz
+          }
+        }
 
-                type Other enum { aa bb }
-            `,
+        type Other enum { aa bb }
+      `,
       {
         annotations: {},
         errors: ["Fatal"],
@@ -149,10 +149,10 @@ describe(Parser, () => {
   test("handles errors", () => {
     expectParses(
       `
-                error Foo
-                error Bar
-                error FooBar
-            `,
+        error Foo
+        error Bar
+        error FooBar
+      `,
       {
         annotations: {},
         errors: ["Foo", "Bar", "FooBar", "Fatal"],
@@ -165,16 +165,16 @@ describe(Parser, () => {
   test("handles combinations of all part", () => {
     expectParses(
       `
-                error Foo
-                error Bar
+        error Foo
+        error Bar
 
-                type Baz {
-                    a: string?
-                    b: int
-                }
+        type Baz {
+          a: string?
+          b: int
+        }
 
-                fn getBaz(): Baz
-            `,
+        fn getBaz(): Baz
+      `,
       {
         annotations: {},
         errors: ["Foo", "Bar", "Fatal"],
@@ -197,17 +197,17 @@ describe(Parser, () => {
   test("fails when struct or enum is empty", () => {
     expectDoesntParse(
       `
-                type Baz {
-                }
-            `,
+        type Baz {
+        }
+      `,
       "empty",
     );
 
     expectDoesntParse(
       `
-                type Baaz enum {
-                }
-            `,
+        type Baaz enum {
+        }
+      `,
       "empty",
     );
   });
@@ -215,30 +215,30 @@ describe(Parser, () => {
   test("fails when field happens twice", () => {
     expectDoesntParse(
       `
-                type Baz {
-                    a: int
-                    b: bool
-                    a: int
-                }
-            `,
+        type Baz {
+          a: int
+          b: bool
+          a: int
+        }
+      `,
       "redeclare",
     );
 
     expectDoesntParse(
       `
-                type Baz {
-                    b: int
-                    xx: bool
-                    xx: int
-                }
-            `,
+        type Baz {
+          b: int
+          xx: bool
+          xx: int
+        }
+      `,
       "redeclare",
     );
 
     expectDoesntParse(
       `
-                fn foo(a: string, a: int)
-            `,
+        fn foo(a: string, a: int)
+      `,
       "redeclare",
     );
   });
@@ -246,15 +246,15 @@ describe(Parser, () => {
   test("handles spreads in structs", () => {
     expectParses(
       `
-                type Bar {
-                    aa: string
-                }
+        type Bar {
+          aa: string
+        }
 
-                type Foo {
-                    ...Bar
-                    bb: int
-                }
-            `,
+        type Foo {
+          ...Bar
+          bb: int
+        }
+      `,
       {
         annotations: {},
         errors: ["Fatal"],
@@ -275,12 +275,12 @@ describe(Parser, () => {
   test("handles functions with arguments", () => {
     expectParses(
       `
-                type Bar {
-                    aa: string
-                }
+        type Bar {
+          aa: string
+        }
 
-                function doIt(foo: int, bar: Bar): string
-            `,
+        function doIt(foo: int, bar: Bar): string
+      `,
       {
         annotations: {},
         errors: ["Fatal"],
@@ -299,19 +299,19 @@ describe(Parser, () => {
           },
         },
       },
-      ["Keyword 'function' is deprecated at -:6:17. Use 'fn' instead."],
+      ["Keyword 'function' is deprecated at -:6:9. Use 'fn' instead."],
     );
   });
 
   test("handles functions with annotations", () => {
     expectParses(
       `
-                @description does it
-                @description and does another \\
-                            thing too
-                @arg bar Represents the number of things
-                fn doIt(foo: int, bar: float): string
-            `,
+        @description does it
+        @description and does another \\
+                     thing too
+        @arg bar Represents the number of things
+        fn doIt(foo: int, bar: float): string
+      `,
       {
         annotations: {
           "fn.doIt": [
@@ -336,14 +336,14 @@ describe(Parser, () => {
 
     expectParses(
       `
-                error NotFound
-                error InvalidArgument
+        error NotFound
+        error InvalidArgument
 
-                @throws NotFound
-                @throws InvalidArgument
-                fn doIt(): string
-                fn doIt2(): int
-            `,
+        @throws NotFound
+        @throws InvalidArgument
+        fn doIt(): string
+        fn doIt2(): int
+      `,
       {
         annotations: {
           "fn.doIt": [
@@ -370,12 +370,12 @@ describe(Parser, () => {
   test("handles descriptions inside structs", () => {
     expectParses(
       `
-                type Foo {
-                    @description foobar
-                    x: int
-                    y: string
-                }
-            `,
+        type Foo {
+          @description foobar
+          x: int
+          y: string
+        }
+      `,
       {
         annotations: {
           "type.Foo.x": [{ type: "description", value: "foobar" }],
@@ -395,15 +395,15 @@ describe(Parser, () => {
   test("handles rest annotations", () => {
     expectParses(
       `
-                @rest GET /foo
-                fn foo(): string
+        @rest GET /foo
+        fn foo(): string
 
-                @rest GET /users/{id}/name
-                fn name(id: string): string
+        @rest GET /users/{id}/name
+        fn name(id: string): string
 
-                @rest GET /users/count?{since}&{until}
-                fn userCount(since: date?, until: date?): uint
-            `,
+        @rest GET /users/count?{since}&{until}
+        fn userCount(since: date?, until: date?): uint
+      `,
       {
         annotations: {
           "fn.foo": [
@@ -472,9 +472,9 @@ describe(Parser, () => {
 
     expectParses(
       `
-                @rest GET /chats/{chatId}/messages?{since}&{until} [header x-token: {token}]
-                fn getMessages(token: base64, chatId: uuid, since: datetime?, until: datetime?): string[]
-            `,
+        @rest GET /chats/{chatId}/messages?{since}&{until} [header x-token: {token}]
+        fn getMessages(token: base64, chatId: uuid, since: datetime?, until: datetime?): string[]
+      `,
       {
         annotations: {
           "fn.getMessages": [
@@ -509,9 +509,9 @@ describe(Parser, () => {
 
     expectParses(
       `
-                @rest GET /posts [header user-agent: {userAgent}] [header accept-language: {lang}] [header x-token: {token}]
-                fn getPosts(userAgent: string, lang: string, token: base64): uuid
-            `,
+        @rest GET /posts [header user-agent: {userAgent}] [header accept-language: {lang}] [header x-token: {token}]
+        fn getPosts(userAgent: string, lang: string, token: base64): uuid
+      `,
       {
         annotations: {
           "fn.getPosts": [
@@ -549,17 +549,17 @@ describe(Parser, () => {
 
     expectParses(
       `
-                type NewUser {
-                    name: string
-                }
+        type NewUser {
+            name: string
+        }
 
-                type User {
-                    id: uuid
-                }
+        type User {
+            id: uuid
+        }
 
-                @rest POST /users [body {user}]
-                fn createNewUser(user: NewUser): User
-            `,
+        @rest POST /users [body {user}]
+        fn createNewUser(user: NewUser): User
+      `,
       {
         annotations: {
           "fn.createNewUser": [
@@ -598,15 +598,15 @@ describe(Parser, () => {
 
     expectParses(
       `
-                type Kind enum {
-                    first
-                    second
-                    third
-                }
+        type Kind enum {
+            first
+            second
+            third
+        }
 
-                @rest GET /things/{kind}
-                fn countThings(kind: Kind): uint
-                `,
+        @rest GET /things/{kind}
+        fn countThings(kind: Kind): uint
+      `,
       {
         annotations: {
           "fn.countThings": [
@@ -640,74 +640,99 @@ describe(Parser, () => {
 
     expectDoesntParse(
       `
-                @rest HEAD /foo
-                fn foo(): string
-            `,
+        @rest HEAD /foo
+        fn foo(): string
+      `,
       "Unsupported method 'HEAD'",
     );
 
     expectDoesntParse(
       `
-                @rest GET /foo/{id}
-                fn foo(): string
-            `,
+        @rest GET /foo/{id}
+        fn foo(): string
+      `,
       "Argument 'id' not found",
     );
 
     expectDoesntParse(
       `
-                @rest GET /foo?{id}
-                fn foo(): string
-            `,
+        @rest GET /foo?{id}
+        fn foo(): string
+      `,
       "Argument 'id' not found",
     );
 
     expectDoesntParse(
       `
-                @rest GET aaa
-                fn foo(): string
-            `,
+        @rest GET aaa
+        fn foo(): string
+      `,
       "Invalid path",
     );
 
     expectDoesntParse(
       `
-                @rest GET /aaa?oug
-                fn foo(): string
-            `,
+        @rest GET /aaa?oug
+        fn foo(): string
+      `,
       "Invalid querystring on path",
     );
 
     expectDoesntParse(
       `
-                @rest GET /aaa/{arg}
-                fn foo(arg: string?): string
-            `,
+        @rest GET /aaa/{arg}
+        fn foo(arg: string?): string
+      `,
       "path argument 'arg' can't be nullable",
     );
 
     expectDoesntParse(
       `
-                @rest GET /aaa/{arg}
-                fn foo(arg: string[]): string
-            `,
+        @rest GET /aaa/{arg}
+        fn foo(arg: string[]): string
+      `,
       "Argument 'arg' can't have type 'string[]' for rest annotation",
     );
 
     expectDoesntParse(
       `
-                @rest GET /aaa
-                fn foo(arg: string): string
-            `,
+        @rest GET /aaa
+        fn foo(arg: string): string
+      `,
       "is missing",
     );
 
     expectDoesntParse(
       `
-                @rest GET /aaa
-                fn foo(): void
-            `,
+        @rest GET /aaa
+        fn foo(): void
+      `,
       "GET rest endpoint must return something",
+    );
+  });
+
+  test("handles functions with @hidden", () => {
+    expectParses(
+      `
+        @hidden
+        fn doIt(foo: int, bar: float): string
+      `,
+      {
+        annotations: {
+          "fn.doIt": [{ type: "hidden", value: null }],
+        },
+        errors: ["Fatal"],
+        functionTable: {
+          doIt: {
+            args: {
+              bar: "float",
+              foo: "int",
+            },
+            ret: "string",
+          },
+        },
+        typeTable: {},
+      },
     );
   });
 });

--- a/parser/src/ast.ts
+++ b/parser/src/ast.ts
@@ -224,3 +224,5 @@ export class RestAnnotation extends Annotation {
     super();
   }
 }
+
+export class HiddenAnnotation extends Annotation {}

--- a/parser/src/json.ts
+++ b/parser/src/json.ts
@@ -6,6 +6,7 @@ import {
   EnumValue,
   Field,
   FunctionOperation,
+  HiddenAnnotation,
   Operation,
   OptionalType,
   RestAnnotation,
@@ -96,6 +97,7 @@ export function astToJson(ast: AstRoot): AstJson {
       args,
       ret: op.returnType.name,
     };
+
     for (const ann of op.annotations) {
       const target = `fn.${op.prettyName}`;
 
@@ -122,6 +124,10 @@ export function astToJson(ast: AstRoot): AstJson {
             queryVariables: ann.queryVariables,
           },
         });
+      }
+
+      if (ann instanceof HiddenAnnotation) {
+        list.push({ type: "hidden", value: null });
       }
     }
   }
@@ -216,6 +222,8 @@ export function jsonToAst(json: AstJson): AstRoot {
         const { method, path, pathVariables, queryVariables, headers, bodyVariable } = annotationJson.value;
 
         op.annotations.push(new RestAnnotation(method, path, pathVariables, queryVariables, new Map(headers), bodyVariable));
+      } else if (annotationJson.type === "hidden") {
+        op.annotations.push(new HiddenAnnotation());
       }
     }
 

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -12,6 +12,7 @@ import {
   Field,
   FunctionOperation,
   GetOperation,
+  HiddenAnnotation,
   Operation,
   OptionalType,
   StructType,
@@ -221,6 +222,14 @@ export class Parser {
           } catch (error) {
             throw new ParserError(`${error.message} at ${this.token.location}`);
           }
+
+          break;
+        case "hidden":
+          if (body !== "") {
+            throw new ParserError(`@hidden annotation doesn't take any argument`);
+          }
+
+          this.annotations.push(new HiddenAnnotation().at(this.token));
 
           break;
         default:

--- a/parser/src/semantic/10_validate_annotations.ts
+++ b/parser/src/semantic/10_validate_annotations.ts
@@ -13,6 +13,7 @@ import {
   Field,
   FloatPrimitiveType,
   HexPrimitiveType,
+  HiddenAnnotation,
   IntPrimitiveType,
   MoneyPrimitiveType,
   Operation,
@@ -61,7 +62,7 @@ export class ValidateAnnotationsVisitor extends Visitor {
         if (annotation instanceof DescriptionAnnotation) {
           // Ok
         } else {
-          throw new SemanticError(`Cannot have this type of annotation at ${annotation.location}`);
+          throw new SemanticError(`Cannot have @${annotation.constructor.name.replace("Annotation", "").toLowerCase()} at ${annotation.location}`);
         }
       }
     } else if (node instanceof TypeDefinition) {
@@ -69,7 +70,7 @@ export class ValidateAnnotationsVisitor extends Visitor {
         if (annotation instanceof DescriptionAnnotation) {
           // Ok
         } else {
-          throw new SemanticError(`Cannot have this type of annotation at ${annotation.location}`);
+          throw new SemanticError(`Cannot have @${annotation.constructor.name.replace("Annotation", "").toLowerCase()} at ${annotation.location}`);
         }
       }
     } else if (node instanceof Field) {
@@ -77,7 +78,7 @@ export class ValidateAnnotationsVisitor extends Visitor {
         if (annotation instanceof DescriptionAnnotation) {
           // Ok
         } else {
-          throw new SemanticError(`Cannot have this type of annotation at ${annotation.location}`);
+          throw new SemanticError(`Cannot have @${annotation.constructor.name.replace("Annotation", "").toLowerCase()} at ${annotation.location}`);
         }
       }
     } else if (node instanceof Operation) {
@@ -122,8 +123,10 @@ export class ValidateAnnotationsVisitor extends Visitor {
           if (annotation.method === "GET" && node.returnType instanceof VoidPrimitiveType) {
             throw new SemanticError(`A GET rest endpoint must return something at ${annotation.location}`);
           }
+        } else if (annotation instanceof HiddenAnnotation) {
+          // Ok
         } else {
-          throw new SemanticError(`Cannot have this type of annotation at ${annotation.location}`);
+          throw new SemanticError(`Cannot have @${annotation.constructor.name.replace("Annotation", "").toLowerCase()} at ${annotation.location}`);
         }
       }
     }

--- a/playground/src/stores/requests.ts
+++ b/playground/src/stores/requests.ts
@@ -153,6 +153,10 @@ export class RequestsStore {
       const argsMock = this.createMockBasedOnTypes(fStruct.args, AST.typeTable);
       const annotations = this.getAnotations(AST, fName);
 
+      if (annotations.func.some(ann => ann.type === "hidden")) {
+        return acc;
+      }
+
       return {
         ...acc,
         [fName]: new requestModel({

--- a/typescript-generator/src/browser-client.ts
+++ b/typescript-generator/src/browser-client.ts
@@ -1,4 +1,4 @@
-import { AstRoot, astToJson } from "@sdkgen/parser";
+import { AstRoot, astToJson, HiddenAnnotation } from "@sdkgen/parser";
 import { generateTypescriptEnum, generateTypescriptErrorClass, generateTypescriptInterface, generateTypescriptTypeName } from "./helpers";
 
 export function generateBrowserClientSource(ast: AstRoot): string {
@@ -28,6 +28,7 @@ export function generateBrowserClientSource(ast: AstRoot): string {
         super(baseUrl, astJson, errClasses);
     }
 ${ast.operations
+  .filter(op => op.annotations.every(ann => !(ann instanceof HiddenAnnotation)))
   .map(
     op => `
     ${op.prettyName}(args${op.args.length === 0 ? "?" : ""}: {${op.args

--- a/typescript-generator/src/node-client.ts
+++ b/typescript-generator/src/node-client.ts
@@ -1,4 +1,4 @@
-import { AstRoot, astToJson } from "@sdkgen/parser";
+import { AstRoot, astToJson, HiddenAnnotation } from "@sdkgen/parser";
 import { generateTypescriptEnum, generateTypescriptErrorClass, generateTypescriptInterface, generateTypescriptTypeName } from "./helpers";
 
 export function generateNodeClientSource(ast: AstRoot): string {
@@ -28,6 +28,7 @@ export function generateNodeClientSource(ast: AstRoot): string {
         super(baseUrl, astJson, errClasses);
     }
 ${ast.operations
+  .filter(op => op.annotations.every(ann => !(ann instanceof HiddenAnnotation)))
   .map(
     op => `
     ${op.prettyName}(ctx: Context | null, args: {${op.args

--- a/vscode-ext/syntaxes/sdkgen.tmLanguage.json
+++ b/vscode-ext/syntaxes/sdkgen.tmLanguage.json
@@ -3,13 +3,17 @@
 	"patterns": [
 		{
 			"include": "#any"
-		}, {
+		},
+		{
 			"include": "#annotations"
-		}, {
+		},
+		{
 			"name": "meta.variable",
 			"begin": "(\\$[a-zA-Z0-9]+) =",
 			"beginCaptures": {
-				"1": {"name": "variable.other"}
+				"1": {
+					"name": "variable.other"
+				}
 			},
 			"end": "\n",
 			"patterns": [
@@ -17,11 +21,14 @@
 					"include": "#literal"
 				}
 			]
-		}, {
+		},
+		{
 			"name": "meta.import",
 			"begin": "(import) ",
 			"beginCaptures": {
-				"1": {"name": "keyword.control"}
+				"1": {
+					"name": "keyword.control"
+				}
 			},
 			"end": "\n",
 			"patterns": [
@@ -29,19 +36,29 @@
 					"include": "#literal"
 				}
 			]
-		}, {
+		},
+		{
 			"name": "meta.error",
 			"match": "(error) ([A-Z][a-zA-Z0-9]*)",
 			"captures": {
-				"1": {"name": "keyword.control"},
-				"2": {"name": "entity.name.type"}
+				"1": {
+					"name": "keyword.control"
+				},
+				"2": {
+					"name": "entity.name.type"
+				}
 			}
-		}, {
+		},
+		{
 			"name": "meta.type",
 			"begin": "(type) ([A-Z][a-zA-Z0-9]*) ",
 			"beginCaptures": {
-				"1": {"name": "keyword.control"},
-				"2": {"name": "entity.name.type"}
+				"1": {
+					"name": "keyword.control"
+				},
+				"2": {
+					"name": "entity.name.type"
+				}
 			},
 			"end": "\n",
 			"patterns": [
@@ -49,12 +66,17 @@
 					"include": "#type"
 				}
 			]
-		}, {
+		},
+		{
 			"name": "meta.operation",
 			"begin": "(get|function|fn) ([a-zA-Z0-9]+)",
 			"beginCaptures": {
-				"1": {"name": "keyword.control"},
-				"2": {"name": "entity.name.function"}
+				"1": {
+					"name": "keyword.control"
+				},
+				"2": {
+					"name": "entity.name.function"
+				}
 			},
 			"end": "\n",
 			"patterns": [
@@ -67,7 +89,8 @@
 							"include": "#fields"
 						}
 					]
-				}, {
+				},
+				{
 					"include": "#type"
 				}
 			]
@@ -93,33 +116,51 @@
 					"name": "meta.annotation.description",
 					"match": "(@description) ((?:.|\\\n)*)\n",
 					"captures": {
-						"1": {"name": "constant.numeric"},
-						"2": {"name": "comment.block.documentation"}
+						"1": {
+							"name": "constant.numeric"
+						},
+						"2": {
+							"name": "comment.block.documentation"
+						}
 					}
 				},
 				{
 					"name": "meta.annotation.arg",
 					"match": "(@arg) (\\w+) ((?:.|\\\\\\n)*)\n",
 					"captures": {
-						"1": {"name": "constant.numeric"},
-						"2": {"name": "variable.parameter"},
-						"3": {"name": "comment.block.documentation"}
+						"1": {
+							"name": "constant.numeric"
+						},
+						"2": {
+							"name": "variable.parameter"
+						},
+						"3": {
+							"name": "comment.block.documentation"
+						}
 					}
 				},
 				{
 					"name": "meta.annotation.throws",
 					"match": "(@throws) (\\w+)\n",
 					"captures": {
-						"1": {"name": "constant.numeric"},
-						"2": {"name": "entity.name.type"}
+						"1": {
+							"name": "constant.numeric"
+						},
+						"2": {
+							"name": "entity.name.type"
+						}
 					}
 				},
 				{
 					"name": "meta.annotations.rest",
 					"begin": "(@rest) (\\w+)",
 					"beginCaptures": {
-						"1": {"name": "constant.numeric"},
-						"2": {"name": "entity.name.type"}
+						"1": {
+							"name": "constant.numeric"
+						},
+						"2": {
+							"name": "entity.name.type"
+						}
 					},
 					"end": "\n",
 					"patterns": [
@@ -128,6 +169,18 @@
 							"match": "\\{\\w+\\}"
 						}
 					]
+				},
+				{
+					"name": "meta.annotation.hidden",
+					"match": "(@hidden)\n",
+					"captures": {
+						"1": {
+							"name": "constant.numeric"
+						},
+						"2": {
+							"name": "entity.name.type"
+						}
+					}
 				}
 			]
 		},
@@ -135,13 +188,17 @@
 			"patterns": [
 				{
 					"include": "#any"
-				}, {
+				},
+				{
 					"include": "#annotations"
-				}, {
+				},
+				{
 					"name": "meta.field",
 					"begin": "(\\w+):",
 					"beginCaptures": {
-						"1": {"name": "variable.parameter"}
+						"1": {
+							"name": "variable.parameter"
+						}
 					},
 					"end": "(?=\n|,|;|\\)|\\})",
 					"patterns": [
@@ -149,12 +206,17 @@
 							"include": "#type"
 						}
 					]
-				}, {
+				},
+				{
 					"name": "meta.spread",
 					"match": "(\\.\\.\\.)\\s?([A-Z][a-zA-Z0-9]*)",
 					"captures": {
-						"1": {"name": "markup.bold"},
-						"2": {"name": "entity.name.type"}
+						"1": {
+							"name": "markup.bold"
+						},
+						"2": {
+							"name": "entity.name.type"
+						}
 					}
 				}
 			]
@@ -163,24 +225,33 @@
 			"patterns": [
 				{
 					"include": "#any"
-				}, {
+				},
+				{
 					"name": "keyword.type",
 					"match": "\\b(bool|int|uint|float|bigint|string|datetime|date|bytes|void|money|cpf|cnpj|email|html|url|uuid|hex|base64|xml|json)\\b"
-				}, {
+				},
+				{
 					"name": "markup.bold",
 					"match": "(\\?|\\[\\])"
-				}, {
+				},
+				{
 					"name": "entity.name.type",
 					"match": "\\b([A-Z][a-zA-Z0-9]*)\\b"
-				}, {
+				},
+				{
 					"name": "constant.numeric",
 					"match": "(![a-zA-Z0-9]+)\\b"
-				}, {
+				},
+				{
 					"name": "meta.type",
 					"begin": "\\{",
 					"beginCaptures": {
-						"1": {"name": "keyword.control"},
-						"2": {"name": "entity.name.type"}
+						"1": {
+							"name": "keyword.control"
+						},
+						"2": {
+							"name": "entity.name.type"
+						}
 					},
 					"end": "\\}",
 					"patterns": [
@@ -188,18 +259,24 @@
 							"include": "#fields"
 						}
 					]
-				}, {
+				},
+				{
 					"name": "meta.enum",
 					"begin": "(enum) \\{",
 					"beginCaptures": {
-						"1": {"name": "keyword.control"},
-						"2": {"name": "entity.name.type"}
+						"1": {
+							"name": "keyword.control"
+						},
+						"2": {
+							"name": "entity.name.type"
+						}
 					},
 					"end": "\\}",
 					"patterns": [
 						{
 							"include": "#any"
-						}, {
+						},
+						{
 							"name": "variable.parameter",
 							"match": "(\\w+)"
 						}
@@ -211,7 +288,8 @@
 			"patterns": [
 				{
 					"include": "#any"
-				}, {
+				},
+				{
 					"name": "string.quoted.double.untitled",
 					"begin": "\"",
 					"end": "\"",
@@ -221,7 +299,8 @@
 							"match": "\\."
 						}
 					]
-				}, {
+				},
+				{
 					"name": "keyword.literal",
 					"match": "\\b(true|false)\\b"
 				}


### PR DESCRIPTION
Example:

```
@hidden
fn getUsers(): User[]
```

Functions marked as `@hidden` won't show in the generated client targets or the playground. This is useful when deprecating an old function (without causing a breaking change) or when creating a function meant to be used as `@rest` only. Hidden functions can still be called from old clients or by someone manually. Do not use this for security!