### PR TITLE
fix: error messages coming with an `Error:` prefix

### DIFF
--- a/node-runtime/spec/rest/rest.spec.ts
+++ b/node-runtime/spec/rest/rest.spec.ts
@@ -246,7 +246,7 @@ describe("Rest API", () => {
       data: `{"val":0}`,
       method: "POST",
       path: "/obj",
-      result: `{"message":"Error: Value is zero ~ spec error","type":"Fatal"}`,
+      result: `{"message":"Value is zero ~ spec error","type":"Fatal"}`,
       resultHeaders: {
         "content-type": "application/json",
       },

--- a/node-runtime/spec/simple/api.sdkgen
+++ b/node-runtime/spec/simple/api.sdkgen
@@ -30,3 +30,6 @@ type AllTypes {
     date: date
     datetime: datetime
 }
+
+error SomeError
+fn throwsError(): void

--- a/node-runtime/spec/simple/simple.spec.ts
+++ b/node-runtime/spec/simple/simple.spec.ts
@@ -27,6 +27,10 @@ api.fn.identity = async (ctx: Context & { aaa: boolean }, { types }: { types: an
   return types;
 };
 
+api.fn.throwsError = async (ctx: Context) => {
+  throw api.err.SomeError("Some message");
+};
+
 // ExecSync(`../../cubos/sdkgen/sdkgen ${__dirname + "/api.sdkgen"} -o ${__dirname + "/legacyNodeClient.ts"} -t typescript_nodeclient`);
 const { ApiClient: NodeLegacyApiClient } = require(`${__dirname}/legacyNodeClient.ts`);
 const nodeLegacyClient = new NodeLegacyApiClient("http://localhost:8000");
@@ -98,5 +102,12 @@ describe("Simple API", () => {
     };
 
     expect(await nodeClient.identity(null, { types })).toEqual(types);
+  });
+
+  test("Errors are passed correctly", async () => {
+    await expect(nodeClient.throwsError(null, {})).rejects.toMatchObject({
+      message: "Some message",
+      type: "SomeError",
+    });
   });
 });

--- a/node-runtime/src/http-server.ts
+++ b/node-runtime/src/http-server.ts
@@ -887,7 +887,7 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
 
   private makeResponseError(err: any): { message: string; type: string } {
     return {
-      message: err.message || err instanceof Error ? err.toString() : typeof err === "object" ? JSON.stringify(err) : `${err}`,
+      message: err.message || (err instanceof Error ? err.toString() : typeof err === "object" ? JSON.stringify(err) : `${err}`),
       type: err.type || "Fatal",
     };
   }


### PR DESCRIPTION
Fixes an issue where errors were passed as `Type: Error: message` instead of `Type: message` to the clients