### PR TITLE
Deprecate api.err in favor of throw

### DIFF
--- a/node-runtime/spec/simple/simple.spec.ts
+++ b/node-runtime/spec/simple/simple.spec.ts
@@ -8,7 +8,7 @@ import { Context, SdkgenHttpServer } from "../../src";
 const ast = new Parser(`${__dirname}/api.sdkgen`).parse();
 
 writeFileSync(`${__dirname}/api.ts`, generateNodeServerSource(ast).replace("@sdkgen/node-runtime", "../../src"));
-const { api } = require(`${__dirname}/api.ts`);
+const { api, SomeError } = require(`${__dirname}/api.ts`);
 
 unlinkSync(`${__dirname}/api.ts`);
 
@@ -28,7 +28,7 @@ api.fn.identity = async (ctx: Context & { aaa: boolean }, { types }: { types: an
 };
 
 api.fn.throwsError = async (ctx: Context) => {
-  throw api.err.SomeError("Some message");
+  throw new SomeError("Some message");
 };
 
 // ExecSync(`../../cubos/sdkgen/sdkgen ${__dirname + "/api.sdkgen"} -o ${__dirname + "/legacyNodeClient.ts"} -t typescript_nodeclient`);

--- a/typescript-generator/src/node-server.ts
+++ b/typescript-generator/src/node-server.ts
@@ -34,6 +34,7 @@ export function generateNodeServerSource(ast: AstRoot): string {
       .join("")}
     }
 
+    /** @deprecated api.err shouldn't be used. Import and throw errors directly. */
     err = {${ast.errors
       .map(
         err => `


### PR DESCRIPTION
There is no reason what so ever to use `api.err.NotFound()` instead of `throw new NotFound()`. Let's deprecate it.