### PR TITLE
Fix: vscode multiline `@description` and `@arg`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,3 +308,17 @@ jobs:
         working-directory: ./dotnetcore-runtime
         env:
           NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
+
+  vscode-ext:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: |
+          npm install -g json && json -I -f package.json -e '
+            this.version = "${{ github.ref }}".replace("refs/tags/", "");
+          '
+        working-directory: ./vscode-ext
+      - run: npm install -g vsce
+      - run: vsce publish -p ${{ secrets.VSCE_TOKEN }}
+        working-directory: ./vscode-ext

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,3 +243,12 @@ jobs:
         with:
           workingdir: "./android-runtime/"
           command1: "./gradlew test assembleRelease"
+
+  vscode-ext:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: npm install -g vsce
+      - run: vsce package
+        working-directory: ./vscode-ext

--- a/vscode-ext/package.json
+++ b/vscode-ext/package.json
@@ -1,35 +1,46 @@
 {
-    "name": "sdkgen",
-    "displayName": "sdkgen",
-    "description": "sdkgen language support",
-    "version": "0.0.0",
-    "publisher": "cubos",
-    "engines": {
-        "vscode": "^1.10.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/sdkgen/sdkgen.git"
-    },
-    "categories": [
-        "Programming Languages",
-        "Snippets"
+  "name": "sdkgen",
+  "displayName": "sdkgen",
+  "description": "sdkgen language support",
+  "version": "0.0.0",
+  "publisher": "cubos",
+  "engines": {
+    "vscode": "^1.10.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdkgen/sdkgen.git"
+  },
+  "categories": [
+    "Programming Languages",
+    "Snippets"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "sdkgen",
+        "aliases": [
+          "sdkgen",
+          "sdkgen"
+        ],
+        "extensions": [
+          ".sdkgen"
+        ],
+        "configuration": "./language-configuration.json"
+      }
     ],
-    "contributes": {
-        "languages": [{
-            "id": "sdkgen",
-            "aliases": ["sdkgen", "sdkgen"],
-            "extensions": [".sdkgen"],
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": "sdkgen",
-            "scopeName": "source.sdkgen",
-            "path": "./syntaxes/sdkgen.tmLanguage.json"
-        }],
-        "snippets": [{
-            "language": "sdkgen",
-            "path": "./snippets/sdkgen.json"
-        }]
-    }
+    "grammars": [
+      {
+        "language": "sdkgen",
+        "scopeName": "source.sdkgen",
+        "path": "./syntaxes/sdkgen.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "sdkgen",
+        "path": "./snippets/sdkgen.json"
+      }
+    ]
+  }
 }

--- a/vscode-ext/syntaxes/sdkgen.tmLanguage.json
+++ b/vscode-ext/syntaxes/sdkgen.tmLanguage.json
@@ -113,8 +113,32 @@
 		"annotations": {
 			"patterns": [
 				{
+					"name": "meta.annotation.description.block",
+					"begin": "(@description) (.*\\\\)\\n",
+					"end": "(.*[^\\\\])\\n",
+					"beginCaptures": {
+						"1": {
+							"name": "constant.numeric"
+						},
+						"2": {
+							"name": "comment.block.documentation"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "comment.block.documentation"
+						}
+					},
+					"patterns": [
+						{
+							"name": "comment.block.documentation",
+							"match": ".*\\\\\\n"
+						}
+					]
+				},
+				{
 					"name": "meta.annotation.description",
-					"match": "(@description) ((?:.|\\\n)*)\n",
+					"match": "(@description) (.*)\\n",
 					"captures": {
 						"1": {
 							"name": "constant.numeric"
@@ -125,8 +149,35 @@
 					}
 				},
 				{
+					"name": "meta.annotation.arg.block",
+					"begin": "(@arg) (\\w+) (.*\\\\)\\n",
+					"end": "(.*[^\\\\])\\n",
+					"beginCaptures": {
+						"1": {
+							"name": "constant.numeric"
+						},
+						"2": {
+							"name": "variable.parameter"
+						},
+						"3": {
+							"name": "comment.block.documentation"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "comment.block.documentation"
+						}
+					},
+					"patterns": [
+						{
+							"name": "comment.block.documentation",
+							"match": ".*\\\\\\n"
+						}
+					]
+				},
+				{
 					"name": "meta.annotation.arg",
-					"match": "(@arg) (\\w+) ((?:.|\\\\\\n)*)\n",
+					"match": "(@arg) (\\w+) (.*)\\n",
 					"captures": {
 						"1": {
 							"name": "constant.numeric"


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/546954/98534065-b1334a00-2262-11eb-8e80-f25d58b068e2.png)

After:
![image](https://user-images.githubusercontent.com/546954/98534085-b8f2ee80-2262-11eb-8953-f43d4c7c0476.png)

This was already handled by the parser correctly.

---

Also: Add CI for publishing the extension.