### PR TITLE
feat: transfer arbitrary data with a sdkgen error

### DIFF
--- a/browser-runtime/src/ast.ts
+++ b/browser-runtime/src/ast.ts
@@ -16,4 +16,5 @@ export type TypeDescription = string | string[] | { [name: string]: TypeDescript
 export interface AstJson {
   typeTable: TypeTable;
   functionTable: FunctionTable;
+  errors: Array<string | string[]>;
 }

--- a/browser-runtime/src/error.ts
+++ b/browser-runtime/src/error.ts
@@ -1,13 +1,25 @@
 export abstract class SdkgenError extends Error {
-  constructor(message?: string) {
-    super(message);
-    this.name = this.constructor.name;
+  get type(): string {
+    return this.constructor.name;
   }
 
   public toJSON(): { message: string; type: string } {
     return {
       message: this.message,
-      type: this.constructor.name,
+      type: this.type,
+    };
+  }
+}
+export abstract class SdkgenErrorWithData<DataType> extends SdkgenError {
+  constructor(message: string, public data: DataType) {
+    super(message);
+  }
+
+  public toJSON(): { data: DataType; message: string; type: string } {
+    return {
+      data: this.data,
+      message: this.message,
+      type: this.type,
     };
   }
 }

--- a/csharp-generator/src/csharp-server.ts
+++ b/csharp-generator/src/csharp-server.ts
@@ -95,9 +95,9 @@ namespace SdkgenGenerated
 `;
   for (const error of ast.errors) {
     code += `
-    public class ${error}Exception : SdkgenException
+    public class ${error.name}Exception : SdkgenException
     {
-        public ${error}Exception(string message, Exception? inner = null) : base("${error}", message, inner) { }
+        public ${error.name}Exception(string message, Exception? inner = null) : base("${error.name}", message, inner) { }
     }
 `;
   }

--- a/dart-generator/src/dart-client.ts
+++ b/dart-generator/src/dart-client.ts
@@ -90,7 +90,9 @@ ${ast.operations
 
   code += `var _errTable = {\n`;
   for (const error of ast.errors) {
-    code += `  "${error}": (msg) => ${error}(msg),\n`;
+    const hasData = !(error.dataType instanceof VoidPrimitiveType);
+
+    code += `  "${error.name}": SdkgenErrorDescription("${error.dataType.name}", (msg, data) => ${error.name}(msg${hasData ? ", data" : ""})),\n`;
   }
 
   code += `};\n`;

--- a/dart-generator/src/helpers.ts
+++ b/dart-generator/src/helpers.ts
@@ -10,6 +10,7 @@ import {
   DateTimePrimitiveType,
   EmailPrimitiveType,
   EnumType,
+  ErrorNode,
   FloatPrimitiveType,
   HexPrimitiveType,
   HtmlPrimitiveType,
@@ -49,10 +50,6 @@ function generateConstructor(type: StructType): string {
   });
   str = str.concat(`${doubleSpace}});\n`);
   return str;
-}
-
-export function generateErrorClass(error: string): string {
-  return `class ${error} extends SdkgenError {\n  ${error}(msg) : super(msg);\n}\n`;
 }
 
 export function generateTypeName(type: Type): string {
@@ -102,6 +99,16 @@ export function generateTypeName(type: Type): string {
     default:
       throw new Error(`BUG: generateTypeName with ${type.constructor.name}`);
   }
+}
+
+export function generateErrorClass(error: ErrorNode): string {
+  if (error.dataType instanceof VoidPrimitiveType) {
+    return `class ${error} extends SdkgenError {\n  ${error}(String msg) : super(msg);\n}\n`;
+  }
+
+  const dataType = generateTypeName(error.dataType);
+
+  return `class ${error} extends SdkgenErrorWithData<${dataType}> {\n  ${error}(String msg, ${dataType} data) : super(msg, data);\n}\n`;
 }
 
 export function cast(value: string, type: Type): string {

--- a/dart-runtime/lib/types.dart
+++ b/dart-runtime/lib/types.dart
@@ -30,6 +30,12 @@ class FunctionDescription {
   FunctionDescription(this.ret, this.args);
 }
 
+class SdkgenErrorDescription {
+  String dataType;
+  Function create;
+  SdkgenErrorDescription(this.dataType, this.create);
+}
+
 class LatLng {
   double lat;
   double lng;

--- a/docs/descrevendo-api.md
+++ b/docs/descrevendo-api.md
@@ -165,6 +165,17 @@ A implementação do servidor poderá lançar esses erros ao longo da execução
 
 Toda API sdkgen possui um erro implícito de nome `Fatal`. Qualquer erro que seja lançado no servidor que não seja um dos erros descritos no contrato da API será convertido em um erro de tipo `Fatal` antes de ser encaminhado ao cliente. Idealmente uma API nunca deve deixar escapar um erro `Fatal`.
 
+Um erro do sdkgen também pode possuir dados adicionais que ajudem a explicar o ocorrido. Esses dados podem ser de qualquer tipo (inclusive objetos) e serão trafegados para o cliente quando o backend lançar o erro. Exemplo:
+
+```
+error InvalidArgument {
+  argumentName: string
+  reason: string
+}
+
+error RetryLater datetime
+```
+
 ### Importando outros arquivos
 
 Conforme uma API se torna maior e mais complexa passa a ser interessante dividir em múltiplos arquivos. Para isso a palavra-chave `import` pode ser utilizada. Por exemplo:

--- a/kotlin-generator/src/android-client.ts
+++ b/kotlin-generator/src/android-client.ts
@@ -1,4 +1,4 @@
-import { AstRoot, HiddenAnnotation } from "@sdkgen/parser";
+import { AstRoot, ErrorNode, HiddenAnnotation, VoidPrimitiveType } from "@sdkgen/parser";
 import { generateClass, generateEnum, generateErrorClass, generateJsonAddRepresentation, generateKotlinTypeName, mangle } from "./helpers";
 
 export function generateAndroidClientSource(ast: AstRoot): string {
@@ -48,14 +48,14 @@ class ApiClient(
 
   const errorTypeEnumEntries: string[] = [];
 
-  const connectionError = "Connection";
+  const connectionError = new ErrorNode("Connection", new VoidPrimitiveType());
 
-  errorTypeEnumEntries.push(connectionError);
+  errorTypeEnumEntries.push(connectionError.name);
   code += `    ${generateErrorClass(connectionError)}`;
 
   for (const error of ast.errors) {
     code += `    ${generateErrorClass(error)}`;
-    errorTypeEnumEntries.push(error);
+    errorTypeEnumEntries.push(error.name);
   }
 
   if (errorTypeEnumEntries.length > 0) {

--- a/kotlin-generator/src/helpers.ts
+++ b/kotlin-generator/src/helpers.ts
@@ -10,6 +10,7 @@ import {
   DateTimePrimitiveType,
   EmailPrimitiveType,
   EnumType,
+  ErrorNode,
   FloatPrimitiveType,
   HexPrimitiveType,
   HtmlPrimitiveType,
@@ -269,6 +270,6 @@ export function generateClass(type: StructType): string {
   return classDesc;
 }
 
-export function generateErrorClass(error: string): string {
-  return `class ${error}(message: String) : Error(message)\n`;
+export function generateErrorClass(error: ErrorNode): string {
+  return `class ${error.name}(message: String) : Error(message)\n`;
 }

--- a/node-runtime/spec/runtime/api.sdkgen
+++ b/node-runtime/spec/runtime/api.sdkgen
@@ -1,0 +1,5 @@
+error CustomError {
+  value: uint
+}
+
+fn throwCustomError(value: uint)

--- a/node-runtime/spec/runtime/runtime.spec.ts
+++ b/node-runtime/spec/runtime/runtime.spec.ts
@@ -1,0 +1,44 @@
+import { Parser } from "@sdkgen/parser";
+import { generateNodeClientSource, generateNodeServerSource } from "@sdkgen/typescript-generator";
+import { unlinkSync, writeFileSync } from "fs";
+import { Context } from "vm";
+import { SdkgenHttpServer } from "../../src";
+
+const ast = new Parser(`${__dirname}/api.sdkgen`).parse();
+
+writeFileSync(`${__dirname}/api.ts`, generateNodeServerSource(ast).replace("@sdkgen/node-runtime", "../../src"));
+const { api, CustomError } = require(`${__dirname}/api.ts`);
+
+unlinkSync(`${__dirname}/api.ts`);
+
+api.fn.throwCustomError = async (ctx: Context, args: { value: number }) => {
+  throw new CustomError("Some message", args);
+};
+
+writeFileSync(`${__dirname}/nodeClient.ts`, generateNodeClientSource(ast).replace("@sdkgen/node-runtime", "../../src"));
+const { ApiClient: NodeApiClient } = require(`${__dirname}/nodeClient.ts`);
+
+unlinkSync(`${__dirname}/nodeClient.ts`);
+const nodeClient = new NodeApiClient("http://localhost:8000");
+
+const server = new SdkgenHttpServer(api, { aaa: true });
+
+describe("Runtime Behavior", () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  test("Errors are passed correctly", async () => {
+    await expect(nodeClient.throwCustomError(null, { value: 235 })).rejects.toMatchObject({
+      data: {
+        value: 235,
+      },
+      message: "Some message",
+      type: "CustomError",
+    });
+  });
+});

--- a/node-runtime/src/error.ts
+++ b/node-runtime/src/error.ts
@@ -1,10 +1,23 @@
-export class SdkgenError extends Error {
+export abstract class SdkgenError extends Error {
   get type(): string {
     return this.constructor.name;
   }
 
   public toJSON(): { message: string; type: string } {
     return {
+      message: this.message,
+      type: this.type,
+    };
+  }
+}
+export abstract class SdkgenErrorWithData<DataType> extends SdkgenError {
+  constructor(message: string, public data: DataType) {
+    super(message);
+  }
+
+  public toJSON(): { data: DataType; message: string; type: string } {
+    return {
+      data: this.data,
       message: this.message,
       type: this.type,
     };

--- a/node-runtime/src/test-wrapper.ts
+++ b/node-runtime/src/test-wrapper.ts
@@ -60,9 +60,13 @@ export function apiTestWrapper<T extends BaseApiConfig<any>>(api: T): T {
 
       if (reply.error) {
         try {
-          throw (api.err[reply.error.type] || api.err.Fatal)(
-            reply.error.message === reply.error.type ? undefined : reply.error.message || reply.error.toString(),
-          );
+          const errorJson = api.astJson.errors.find(err => reply && (Array.isArray(err) ? err[0] === reply.error.type : err === reply.error.type));
+
+          if (errorJson) {
+            throw reply.error;
+          } else {
+            throw api.err.Fatal(reply.error.message === reply.error.type ? undefined : reply.error.message || reply.error.toString());
+          }
         } catch (err) {
           if (reply.error.stack) {
             err.stack = reply.error.stack;

--- a/parser/spec/parser.spec.ts
+++ b/parser/spec/parser.spec.ts
@@ -150,14 +150,20 @@ describe(Parser, () => {
     expectParses(
       `
         error Foo
-        error Bar
-        error FooBar
+        error Bar {
+          foo: string
+        }
+        error FooBar int
       `,
       {
         annotations: {},
-        errors: ["Foo", "Bar", "FooBar", "Fatal"],
+        errors: ["Foo", ["Bar", "BarData"], ["FooBar", "int"], "Fatal"],
         functionTable: {},
-        typeTable: {},
+        typeTable: {
+          BarData: {
+            foo: "string",
+          },
+        },
       },
     );
   });

--- a/parser/src/ast.ts
+++ b/parser/src/ast.ts
@@ -7,7 +7,7 @@ export class AstRoot {
 
   warnings: string[] = [];
 
-  constructor(public typeDefinitions: TypeDefinition[] = [], public operations: Operation[] = [], public errors: string[] = []) {}
+  constructor(public typeDefinitions: TypeDefinition[] = [], public operations: Operation[] = [], public errors: ErrorNode[] = []) {}
 }
 
 export abstract class AstNode {
@@ -25,6 +25,12 @@ export abstract class AstNode {
   atLocation(location: TokenLocation): this {
     this.location = location;
     return this;
+  }
+}
+
+export class ErrorNode extends AstNode {
+  constructor(public name: string, public dataType: Type) {
+    super();
   }
 }
 

--- a/parser/src/compatibility/index.ts
+++ b/parser/src/compatibility/index.ts
@@ -249,5 +249,15 @@ export function compatibilityIssues(ast1: AstRoot, ast2: AstRoot): string[] {
     }
   }
 
+  for (const err1 of ast1.errors) {
+    const err2 = ast2.errors.find(x => x.name === err1.name);
+
+    if (!err2) {
+      continue;
+    }
+
+    checkServerToClient(`${err1.name}.data`, issues, err1.dataType, err2.dataType);
+  }
+
   return issues;
 }

--- a/parser/src/semantic/06_give_struct_and_enum_names.ts
+++ b/parser/src/semantic/06_give_struct_and_enum_names.ts
@@ -1,4 +1,4 @@
-import { AstNode, EnumType, Field, Operation, StructType, Type, TypeDefinition } from "../ast";
+import { AstNode, EnumType, ErrorNode, Field, Operation, StructType, Type, TypeDefinition } from "../ast";
 import { SemanticError } from "./analyser";
 import { Visitor } from "./visitor";
 
@@ -10,6 +10,9 @@ export class GiveStructAndEnumNamesVisitor extends Visitor {
   visit(node: AstNode): void {
     if (node instanceof TypeDefinition) {
       this.path = [node.name];
+      super.visit(node);
+    } else if (node instanceof ErrorNode) {
+      this.path = [`${node.name}Data`];
       super.visit(node);
     } else if (node instanceof Operation) {
       this.path = [node.name];

--- a/parser/src/semantic/10_validate_annotations.ts
+++ b/parser/src/semantic/10_validate_annotations.ts
@@ -86,7 +86,7 @@ export class ValidateAnnotationsVisitor extends Visitor {
         if (annotation instanceof DescriptionAnnotation) {
           // Ok
         } else if (annotation instanceof ThrowsAnnotation) {
-          if (!this.root.errors.includes(annotation.error)) {
+          if (!this.root.errors.some(error => error.name === annotation.error)) {
             throw new SemanticError(`Unknown error type '${annotation.error}' at ${annotation.location}`);
           }
         } else if (annotation instanceof RestAnnotation) {

--- a/parser/src/semantic/analyser.ts
+++ b/parser/src/semantic/analyser.ts
@@ -1,4 +1,4 @@
-import { AstRoot } from "../ast";
+import { AstRoot, ErrorNode, VoidPrimitiveType } from "../ast";
 import { CheckMultipleDeclarationVisitor } from "./01_check_multiple_declaration";
 import { MatchTypeDefinitionsVisitor } from "./02_match_type_definitions";
 import { CheckNoRecursiveTypesVisitor } from "./03_check_no_recursive_types";
@@ -13,8 +13,9 @@ import { ValidateAnnotationsVisitor } from "./10_validate_annotations";
 export class SemanticError extends Error {}
 
 export function analyse(root: AstRoot): void {
-  root.errors.push("Fatal");
-  root.errors = [...new Set(root.errors)];
+  if (!root.errors.some(error => error.name === "Fatal")) {
+    root.errors.push(new ErrorNode("Fatal", new VoidPrimitiveType()));
+  }
 
   new CheckMultipleDeclarationVisitor(root).process();
   new MatchTypeDefinitionsVisitor(root).process();

--- a/parser/src/semantic/visitor.ts
+++ b/parser/src/semantic/visitor.ts
@@ -1,9 +1,13 @@
-import { ArrayType, AstNode, AstRoot, Field, Operation, OptionalType, StructType, TypeDefinition } from "../ast";
+import { ArrayType, AstNode, AstRoot, ErrorNode, Field, Operation, OptionalType, StructType, TypeDefinition } from "../ast";
 
 export abstract class Visitor {
   constructor(protected root: AstRoot) {}
 
   process(): void {
+    for (const error of this.root.errors) {
+      this.visit(error);
+    }
+
     for (const typeDefinition of this.root.typeDefinitions) {
       this.visit(typeDefinition);
     }
@@ -32,6 +36,8 @@ export abstract class Visitor {
       }
     } else if (node instanceof ArrayType || node instanceof OptionalType) {
       this.visit(node.base);
+    } else if (node instanceof ErrorNode) {
+      this.visit(node.dataType);
     }
   }
 }

--- a/typescript-generator/src/browser-client.ts
+++ b/typescript-generator/src/browser-client.ts
@@ -4,7 +4,7 @@ import { generateTypescriptEnum, generateTypescriptErrorClass, generateTypescrip
 export function generateBrowserClientSource(ast: AstRoot): string {
   let code = "";
 
-  code += `import { SdkgenError, SdkgenHttpClient } from "@sdkgen/browser-runtime";
+  code += `import { SdkgenError, SdkgenErrorWithData, SdkgenHttpClient } from "@sdkgen/browser-runtime";
 
 `;
 
@@ -38,7 +38,7 @@ ${ast.operations
   .join("")}
 }\n\n`;
 
-  code += `const errClasses = {\n${ast.errors.map(err => `    ${err}`).join(",\n")}\n};\n\n`;
+  code += `const errClasses = {\n${ast.errors.map(err => `    ${err.name}`).join(",\n")}\n};\n\n`;
 
   code += `const astJson = ${JSON.stringify(astToJson(ast), null, 4).replace(/"(?<key>\w+)":/gu, "$<key>:")};\n`;
 

--- a/typescript-generator/src/helpers.ts
+++ b/typescript-generator/src/helpers.ts
@@ -10,6 +10,7 @@ import {
   DateTimePrimitiveType,
   EmailPrimitiveType,
   EnumType,
+  ErrorNode,
   FloatPrimitiveType,
   HexPrimitiveType,
   HtmlPrimitiveType,
@@ -103,8 +104,10 @@ export function generateTypescriptEnum(type: EnumType): string {
   return `export type ${type.name} = ${type.values.map(x => `"${x.value}"`).join(" | ")};\n`;
 }
 
-export function generateTypescriptErrorClass(name: string): string {
-  return `export class ${name} extends SdkgenError {}\n`;
+export function generateTypescriptErrorClass(error: ErrorNode): string {
+  return `export class ${error.name} extends ${
+    error.dataType instanceof VoidPrimitiveType ? "SdkgenError" : `SdkgenErrorWithData<${generateTypescriptTypeName(error.dataType)}>`
+  } {}\n`;
 }
 
 export function clearForLogging(path: string, type: Type): string {

--- a/typescript-generator/src/node-client.ts
+++ b/typescript-generator/src/node-client.ts
@@ -4,7 +4,7 @@ import { generateTypescriptEnum, generateTypescriptErrorClass, generateTypescrip
 export function generateNodeClientSource(ast: AstRoot): string {
   let code = "";
 
-  code += `import { Context, SdkgenError, SdkgenHttpClient } from "@sdkgen/node-runtime";
+  code += `import { Context, SdkgenError, SdkgenHttpClient, SdkgenErrorWithData } from "@sdkgen/node-runtime";
 
 `;
 
@@ -38,7 +38,7 @@ ${ast.operations
   .join("")}
 }\n\n`;
 
-  code += `const errClasses = {\n${ast.errors.map(err => `    ${err}`).join(",\n")}\n};\n\n`;
+  code += `const errClasses = {\n${ast.errors.map(err => `    ${err.name}`).join(",\n")}\n};\n\n`;
 
   code += `const astJson = ${JSON.stringify(astToJson(ast), null, 4).replace(/"(?<key>\w+)":/gu, "$<key>:")};\n`;
 

--- a/typescript-generator/src/node-server.ts
+++ b/typescript-generator/src/node-server.ts
@@ -1,10 +1,10 @@
-import { AstRoot, astToJson } from "@sdkgen/parser";
+import { AstRoot, astToJson, VoidPrimitiveType } from "@sdkgen/parser";
 import { generateTypescriptEnum, generateTypescriptErrorClass, generateTypescriptInterface, generateTypescriptTypeName } from "./helpers";
 
 export function generateNodeServerSource(ast: AstRoot): string {
   let code = "";
 
-  code += `import { BaseApiConfig, Context, SdkgenError } from "@sdkgen/node-runtime";
+  code += `import { BaseApiConfig, Context, SdkgenError, SdkgenErrorWithData } from "@sdkgen/node-runtime";
 
 `;
 
@@ -36,9 +36,10 @@ export function generateNodeServerSource(ast: AstRoot): string {
 
     /** @deprecated api.err shouldn't be used. Import and throw errors directly. */
     err = {${ast.errors
+      .filter(err => err.dataType instanceof VoidPrimitiveType)
       .map(
         err => `
-        ${err}(message: string = "") { throw new ${err}(message); }`,
+        ${err.name}(message: string = "") { throw new ${err.name}(message); }`,
       )
       .join(",")}
     }

--- a/vscode-ext/syntaxes/sdkgen.tmLanguage.json
+++ b/vscode-ext/syntaxes/sdkgen.tmLanguage.json
@@ -39,15 +39,21 @@
 		},
 		{
 			"name": "meta.error",
-			"match": "(error) ([A-Z][a-zA-Z0-9]*)",
-			"captures": {
+			"begin": "(error) ([A-Z][a-zA-Z0-9]*) ",
+			"beginCaptures": {
 				"1": {
 					"name": "keyword.control"
 				},
 				"2": {
 					"name": "entity.name.type"
 				}
-			}
+			},
+			"end": "\n",
+			"patterns": [
+				{
+					"include": "#type"
+				}
+			]
 		},
 		{
 			"name": "meta.type",


### PR DESCRIPTION
Example:

```
error InvalidArgument {
  argumentName: string
  reason: string
}

error RetryLater datetime
```

This change is backward compatible.