### PR TITLE
Kotlin - encode base64 with NO_WRAP option

### DIFF
--- a/kotlin-generator/src/helpers.ts
+++ b/kotlin-generator/src/helpers.ts
@@ -213,7 +213,7 @@ export function generateJsonAddRepresentation(type: Type, fieldName: string): st
     case VoidPrimitiveType:
       return "";
     case BytesPrimitiveType:
-      return `addProperty("${fieldName}", Base64.encodeToString(${mangle(fieldName)}, Base64.DEFAULT))`;
+      return `addProperty("${fieldName}", Base64.encodeToString(${mangle(fieldName)}, Base64.NO_WRAP))`;
     default:
       throw new Error(`BUG: No result found for generateJsonRepresentation with ${type.constructor.name}`);
   }


### PR DESCRIPTION
Fixing error - Node was not able to decode when Android client was sending a `bytes` parameter. It expects no `\n` in the content.