### PR TITLE
fix(dart-runtime): don't re-throw SdkgenErrorWithData as Fatal errors

### DIFF
--- a/dart-runtime/lib/http_client.dart
+++ b/dart-runtime/lib/http_client.dart
@@ -136,7 +136,7 @@ class SdkgenHttpClient {
             typeTable, "$functionName.ret", func.ret, responseBody["result"]);
       }
     } catch (e) {
-      if (e is SdkgenError)
+      if (e is SdkgenError || e is SdkgenErrorWithData)
         throw e;
       else
         throw _throwError("Fatal", e.toString(), null);


### PR DESCRIPTION
sdkgen wasn't handling `SdkgenErrorWithData` properly and rethrowing them as Fatal errors