### PR TITLE
fix: Improve selection of best REST route when there is more than one match

### DIFF
--- a/dart-generator/package.json
+++ b/dart-generator/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/sdkgen/sdkgen#readme",
   "devDependencies": {
+    "@cubos/eslint-config": "^1.0.442740",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.9",
     "jest": "^26.5.3",
-    "@cubos/eslint-config": "^1.0.442740",
     "ts-jest": "^26.4.1",
     "typescript": "^4.0.3"
   },

--- a/node-runtime/spec/rest/api.sdkgen
+++ b/node-runtime/spec/rest/api.sdkgen
@@ -42,3 +42,7 @@ fn returnArg(arg: string): string
 
 @rest GET /foo/baz/hello
 fn returnNoArg(): string
+
+@rest GET /foo/{arg}/hello/{arg2}/world
+@rest GET /foo/bar{arg}/hello/bar{arg2}/world
+fn returnArgConcat(arg: string, arg2: string): string

--- a/node-runtime/spec/rest/api.sdkgen
+++ b/node-runtime/spec/rest/api.sdkgen
@@ -35,3 +35,10 @@ fn getHtml(): html
 
 @rest GET /xml
 fn getXml(): xml
+
+@rest GET /foo/{arg}/hello
+@rest GET /foo/bar{arg}/hello
+fn returnArg(arg: string): string
+
+@rest GET /foo/baz/hello
+fn returnNoArg(): string

--- a/node-runtime/spec/rest/rest.spec.ts
+++ b/node-runtime/spec/rest/rest.spec.ts
@@ -56,6 +56,10 @@ api.fn.returnNoArg = async () => {
   return "no-arg";
 };
 
+api.fn.returnArgConcat = async (ctx: Context, { arg, arg2 }: { arg: string; arg2: string }) => {
+  return `${arg}${arg2}`;
+};
+
 async function readAllStream(stream: Readable) {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -333,6 +337,21 @@ describe("Rest API", () => {
       method: "GET",
       path: "/foo/baz/hello",
       result: "no-arg",
+    },
+    {
+      method: "GET",
+      path: "/foo/haha/hello/hehe/world",
+      result: "hahahehe",
+    },
+    {
+      method: "GET",
+      path: "/foo/barhaha/hello/barhehe/world",
+      result: "hahahehe",
+    },
+    {
+      method: "GET",
+      path: "/foo/bar/hello/bar/world",
+      result: "barbar",
     },
     (() => {
       const form = new FormData();

--- a/node-runtime/spec/rest/rest.spec.ts
+++ b/node-runtime/spec/rest/rest.spec.ts
@@ -48,6 +48,14 @@ api.fn.obj = async (ctx: Context, { obj }: { obj: { val: number } }) => {
   return obj;
 };
 
+api.fn.returnArg = async (ctx: Context, { arg }: { arg: string }) => {
+  return arg;
+};
+
+api.fn.returnNoArg = async () => {
+  return "no-arg";
+};
+
 async function readAllStream(stream: Readable) {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -85,8 +93,8 @@ const nodeClient = new NodeApiClient("http://localhost:8001");
 const server = new SdkgenHttpServer(api, {});
 
 describe("Rest API", () => {
-  beforeAll(() => {
-    server.listen(8001);
+  beforeAll(async () => {
+    await server.listen(8001);
   });
 
   afterAll(async () => {
@@ -305,6 +313,26 @@ describe("Rest API", () => {
       resultHeaders: {
         "content-type": "text/xml",
       },
+    },
+    {
+      method: "GET",
+      path: "/foo/haha/hello",
+      result: "haha",
+    },
+    {
+      method: "GET",
+      path: "/foo/barhaha/hello",
+      result: "haha",
+    },
+    {
+      method: "GET",
+      path: "/foo/bar/hello",
+      result: "bar",
+    },
+    {
+      method: "GET",
+      path: "/foo/baz/hello",
+      result: "no-arg",
     },
     (() => {
       const form = new FormData();

--- a/parser/package.json
+++ b/parser/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/sdkgen/sdkgen#readme",
   "devDependencies": {
+    "@cubos/eslint-config": "^1.0.442740",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.9",
     "jest": "^26.5.3",
-    "@cubos/eslint-config": "^1.0.442740",
     "ts-jest": "^26.4.1",
     "typescript": "^4.0.3"
   },
@@ -44,6 +44,5 @@
     "coveragePathIgnorePatterns": [
       "/node_modules/"
     ]
-  },
-  "dependencies": {}
+  }
 }

--- a/typescript-generator/package.json
+++ b/typescript-generator/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/sdkgen/sdkgen#readme",
   "devDependencies": {
+    "@cubos/eslint-config": "^1.0.442740",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.9",
     "jest": "^26.5.3",
-    "@cubos/eslint-config": "^1.0.442740",
     "ts-jest": "^26.4.1",
     "typescript": "^4.0.3"
   },


### PR DESCRIPTION
This PR introduces two fixes that may be seen as breaking changes:

- When matching a route argument, don't allow "/" anymore.

      @rest GET /hello/{arg}/123
      fn someFunction(arg: string): string

    Previously this could match `/hello/a/b/c/123` with `arg = "a/b/c"`. Now it can't.

- When more than one route do match, prefer the one with more matching non-argument characters.

      @rest GET /hello/{arg}
      fn someFunction1(arg: string): string

      @rest GET /hello/special-{arg}
      fn someFunction2(arg: string): string

    Now `/hello/aaa` will match the `someFunction1` and `/hello/special-aaa` will match `someFunction2`.

I believe these changes makes everything more intuitive. It was just broken before.