### PR TITLE
fix: don't encode invalid dates

### DIFF
--- a/browser-runtime/src/encode-decode.ts
+++ b/browser-runtime/src/encode-decode.ts
@@ -162,14 +162,14 @@ export function encode(typeTable: DeepReadonly<TypeTable>, path: string, type: D
 
     return value;
   } else if (type === "date") {
-    if (!(value instanceof Date) && !(typeof value === "string" && /^[0-9]{4}-[01][0-9]-[0123][0-9]$/u.test(value))) {
+    if (!(value instanceof Date && !isNaN(value.getTime())) && !(typeof value === "string" && /^[0-9]{4}-[01][0-9]-[0123][0-9]$/u.test(value))) {
       throw new ParseError(path, type, value);
     }
 
     return typeof value === "string" ? new Date(value).toISOString().split("T")[0] : value.toISOString().split("T")[0];
   } else if (type === "datetime") {
     if (
-      !(value instanceof Date) &&
+      !(value instanceof Date && !isNaN(value.getTime())) &&
       !(
         typeof value === "string" &&
         /^[0-9]{4}-[01][0-9]-[0123][0-9]T[012][0-9]:[0123456][0-9]:[0123456][0-9](?:\.[0-9]{1,6})?(?:Z|[+-][012][0-9]:[0123456][0-9])?$/u.test(value)

--- a/node-runtime/spec/types.spec.ts
+++ b/node-runtime/spec/types.spec.ts
@@ -70,6 +70,9 @@ describe("Encode/Decode", () => {
     expect(() => {
       decode({}, "", "date", "2020-02-30");
     }).toThrow();
+    expect(() => {
+      encode({}, "", "date", new Date(""));
+    }).toThrow();
   });
 
   test("Process Datetime", () => {
@@ -92,6 +95,9 @@ describe("Encode/Decode", () => {
     }).toThrow();
     expect(decode({}, "", "datetime", "2020-11-10T15:34:50Z").getTime()).toBe(new Date("2020-11-10T15:34:50Z").getTime());
     expect(decode({}, "", "datetime", "2020-11-10T15:34:50.000").getTime()).toBe(new Date("2020-11-10T15:34:50Z").getTime());
+    expect(() => {
+      encode({}, "", "datetime", new Date(""));
+    }).toThrow();
   });
 
   test("Process BigInt", () => {

--- a/node-runtime/src/encode-decode.ts
+++ b/node-runtime/src/encode-decode.ts
@@ -240,14 +240,14 @@ export function encode<Table extends DeepReadonly<TypeTable>, Type extends DeepR
 
     return CNPJ.strip(value) as EncodedType<Type, Table>;
   } else if (type === "date") {
-    if (!(value instanceof Date) && !(typeof value === "string" && /^[0-9]{4}-[01][0-9]-[0123][0-9]$/u.test(value))) {
+    if (!(value instanceof Date && !isNaN(value.getTime())) && !(typeof value === "string" && /^[0-9]{4}-[01][0-9]-[0123][0-9]$/u.test(value))) {
       throw new ParseError(path, type, value);
     }
 
     return (typeof value === "string" ? new Date(value).toISOString().split("T")[0] : value.toISOString().split("T")[0]) as EncodedType<Type, Table>;
   } else if (type === "datetime") {
     if (
-      !(value instanceof Date) &&
+      !(value instanceof Date && !isNaN(value.getTime())) &&
       !(
         typeof value === "string" &&
         /^[0-9]{4}-[01][0-9]-[0123][0-9]T[012][0-9]:[0123456][0-9]:[0123456][0-9](?:\.[0-9]{1,6})?(?:Z|[+-][012][0-9]:[0123456][0-9])?$/u.test(value)


### PR DESCRIPTION
`new Date("whatever")` produces a instance of `Date` containing an invalid date. This value can't be encoded. Calling `toISOString()` on it throws.