### PR TITLE
Release 1.5.4

### DIFF
--- a/browser-runtime/src/encode-decode.ts
+++ b/browser-runtime/src/encode-decode.ts
@@ -207,7 +207,7 @@ export function decode(typeTable: DeepReadonly<TypeTable>, path: string, type: D
     const obj: Record<string, unknown> = {};
 
     for (const key of Object.keys(type)) {
-      obj[key] = encode(typeTable, `${path}.${key}`, (type as Record<string, TypeDescription>)[key], (value as Record<string, unknown>)[key]);
+      obj[key] = decode(typeTable, `${path}.${key}`, (type as Record<string, TypeDescription>)[key], (value as Record<string, unknown>)[key]);
     }
 
     return obj;

--- a/browser-runtime/src/encode-decode.ts
+++ b/browser-runtime/src/encode-decode.ts
@@ -162,14 +162,14 @@ export function encode(typeTable: DeepReadonly<TypeTable>, path: string, type: D
 
     return value;
   } else if (type === "date") {
-    if (!(value instanceof Date) && !(typeof value === "string" && /^[0-9]{4}-[01][0-9]-[0123][0-9]$/u.test(value))) {
+    if (!(value instanceof Date && !isNaN(value.getTime())) && !(typeof value === "string" && /^[0-9]{4}-[01][0-9]-[0123][0-9]$/u.test(value))) {
       throw new ParseError(path, type, value);
     }
 
     return typeof value === "string" ? new Date(value).toISOString().split("T")[0] : value.toISOString().split("T")[0];
   } else if (type === "datetime") {
     if (
-      !(value instanceof Date) &&
+      !(value instanceof Date && !isNaN(value.getTime())) &&
       !(
         typeof value === "string" &&
         /^[0-9]{4}-[01][0-9]-[0123][0-9]T[012][0-9]:[0123456][0-9]:[0123456][0-9](?:\.[0-9]{1,6})?(?:Z|[+-][012][0-9]:[0123456][0-9])?$/u.test(value)

--- a/dart-generator/package.json
+++ b/dart-generator/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/sdkgen/sdkgen#readme",
   "devDependencies": {
+    "@cubos/eslint-config": "^1.0.442740",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.9",
     "jest": "^26.5.3",
-    "@cubos/eslint-config": "^1.0.442740",
     "ts-jest": "^26.4.1",
     "typescript": "^4.0.3"
   },

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,14 @@
 # Releases
 
+## 1.5.4 (2021-02-19)
+
+**Correções:**
+- Correção no recebimento de objetos retornados pela API no browser-runtime ([#181](https://github.com/sdkgen/sdkgen/pull/181)).
+- Correção no tratamento de rotas REST para que caso mais de uma rota encaixe com uma requisição, aquela que contém a maior quantidade de caracteres que não fazem parte dos argumentos seja escolhida ([#179](https://github.com/sdkgen/sdkgen/pull/179)).
+- Mudança no tratamento de rotas REST de forma que argumentos do tipo `string` dentra da path não possam mais conter o caracter `/` ([#179](https://github.com/sdkgen/sdkgen/pull/179)).
+- Validação de datas no browser-runtime e node-runtime de forma que uma data inválida não seja aceita ([#180](https://github.com/sdkgen/sdkgen/pull/180)).
+- Atualização de dependências.
+
 ## 1.5.3 (2021-02-10)
 
 **Correção:**

--- a/node-runtime/package.json
+++ b/node-runtime/package.json
@@ -36,7 +36,7 @@
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-prettier": "^3.1.2",
-    "form-data": "^3.0.0",
+    "form-data": "^4.0.0",
     "jest": "^26.5.3",
     "json-schema-typed": "^7.0.3",
     "ts-jest": "^26.4.1",

--- a/node-runtime/spec/rest/api.sdkgen
+++ b/node-runtime/spec/rest/api.sdkgen
@@ -35,3 +35,14 @@ fn getHtml(): html
 
 @rest GET /xml
 fn getXml(): xml
+
+@rest GET /foo/{arg}/hello
+@rest GET /foo/bar{arg}/hello
+fn returnArg(arg: string): string
+
+@rest GET /foo/baz/hello
+fn returnNoArg(): string
+
+@rest GET /foo/{arg}/hello/{arg2}/world
+@rest GET /foo/bar{arg}/hello/bar{arg2}/world
+fn returnArgConcat(arg: string, arg2: string): string

--- a/node-runtime/spec/rest/rest.spec.ts
+++ b/node-runtime/spec/rest/rest.spec.ts
@@ -48,6 +48,18 @@ api.fn.obj = async (ctx: Context, { obj }: { obj: { val: number } }) => {
   return obj;
 };
 
+api.fn.returnArg = async (ctx: Context, { arg }: { arg: string }) => {
+  return arg;
+};
+
+api.fn.returnNoArg = async () => {
+  return "no-arg";
+};
+
+api.fn.returnArgConcat = async (ctx: Context, { arg, arg2 }: { arg: string; arg2: string }) => {
+  return `${arg}${arg2}`;
+};
+
 async function readAllStream(stream: Readable) {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -85,8 +97,8 @@ const nodeClient = new NodeApiClient("http://localhost:8001");
 const server = new SdkgenHttpServer(api, {});
 
 describe("Rest API", () => {
-  beforeAll(() => {
-    server.listen(8001);
+  beforeAll(async () => {
+    await server.listen(8001);
   });
 
   afterAll(async () => {
@@ -305,6 +317,41 @@ describe("Rest API", () => {
       resultHeaders: {
         "content-type": "text/xml",
       },
+    },
+    {
+      method: "GET",
+      path: "/foo/haha/hello",
+      result: "haha",
+    },
+    {
+      method: "GET",
+      path: "/foo/barhaha/hello",
+      result: "haha",
+    },
+    {
+      method: "GET",
+      path: "/foo/bar/hello",
+      result: "bar",
+    },
+    {
+      method: "GET",
+      path: "/foo/baz/hello",
+      result: "no-arg",
+    },
+    {
+      method: "GET",
+      path: "/foo/haha/hello/hehe/world",
+      result: "hahahehe",
+    },
+    {
+      method: "GET",
+      path: "/foo/barhaha/hello/barhehe/world",
+      result: "hahahehe",
+    },
+    {
+      method: "GET",
+      path: "/foo/bar/hello/bar/world",
+      result: "barbar",
     },
     (() => {
       const form = new FormData();

--- a/node-runtime/spec/types.spec.ts
+++ b/node-runtime/spec/types.spec.ts
@@ -70,6 +70,9 @@ describe("Encode/Decode", () => {
     expect(() => {
       decode({}, "", "date", "2020-02-30");
     }).toThrow();
+    expect(() => {
+      encode({}, "", "date", new Date(""));
+    }).toThrow();
   });
 
   test("Process Datetime", () => {
@@ -92,6 +95,9 @@ describe("Encode/Decode", () => {
     }).toThrow();
     expect(decode({}, "", "datetime", "2020-11-10T15:34:50Z").getTime()).toBe(new Date("2020-11-10T15:34:50Z").getTime());
     expect(decode({}, "", "datetime", "2020-11-10T15:34:50.000").getTime()).toBe(new Date("2020-11-10T15:34:50Z").getTime());
+    expect(() => {
+      encode({}, "", "datetime", new Date(""));
+    }).toThrow();
   });
 
   test("Process BigInt", () => {

--- a/node-runtime/src/encode-decode.ts
+++ b/node-runtime/src/encode-decode.ts
@@ -240,14 +240,14 @@ export function encode<Table extends DeepReadonly<TypeTable>, Type extends DeepR
 
     return CNPJ.strip(value) as EncodedType<Type, Table>;
   } else if (type === "date") {
-    if (!(value instanceof Date) && !(typeof value === "string" && /^[0-9]{4}-[01][0-9]-[0123][0-9]$/u.test(value))) {
+    if (!(value instanceof Date && !isNaN(value.getTime())) && !(typeof value === "string" && /^[0-9]{4}-[01][0-9]-[0123][0-9]$/u.test(value))) {
       throw new ParseError(path, type, value);
     }
 
     return (typeof value === "string" ? new Date(value).toISOString().split("T")[0] : value.toISOString().split("T")[0]) as EncodedType<Type, Table>;
   } else if (type === "datetime") {
     if (
-      !(value instanceof Date) &&
+      !(value instanceof Date && !isNaN(value.getTime())) &&
       !(
         typeof value === "string" &&
         /^[0-9]{4}-[01][0-9]-[0123][0-9]T[012][0-9]:[0123456][0-9]:[0123456][0-9](?:\.[0-9]{1,6})?(?:Z|[+-][012][0-9]:[0123456][0-9])?$/u.test(value)

--- a/parser/package.json
+++ b/parser/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/sdkgen/sdkgen#readme",
   "devDependencies": {
+    "@cubos/eslint-config": "^1.0.442740",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.9",
     "jest": "^26.5.3",
-    "@cubos/eslint-config": "^1.0.442740",
     "ts-jest": "^26.4.1",
     "typescript": "^4.0.3"
   },
@@ -44,6 +44,5 @@
     "coveragePathIgnorePatterns": [
       "/node_modules/"
     ]
-  },
-  "dependencies": {}
+  }
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -41,7 +41,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.8",
     "@loadable/component": "^5.12.0",
-    "@types/chrome": "0.0.128",
+    "@types/chrome": "0.0.130",
     "@types/classnames": "^2.2.9",
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",

--- a/typescript-generator/package.json
+++ b/typescript-generator/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/sdkgen/sdkgen#readme",
   "devDependencies": {
+    "@cubos/eslint-config": "^1.0.442740",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.9",
     "jest": "^26.5.3",
-    "@cubos/eslint-config": "^1.0.442740",
     "ts-jest": "^26.4.1",
     "typescript": "^4.0.3"
   },


### PR DESCRIPTION
## 1.5.4 (2021-02-19)

**Correções:**
- Correção no recebimento de objetos retornados pela API no browser-runtime ([#181](https://github.com/sdkgen/sdkgen/pull/181)).
- Correção no tratamento de rotas REST para que caso mais de uma rota encaixe com uma requisição, aquela que contém a maior quantidade de caracteres que não fazem parte dos argumentos seja escolhida ([#179](https://github.com/sdkgen/sdkgen/pull/179)).
- Mudança no tratamento de rotas REST de forma que argumentos do tipo `string` dentra da path não possam mais conter o caracter `/` ([#179](https://github.com/sdkgen/sdkgen/pull/179)).
- Validação de datas no browser-runtime e node-runtime de forma que uma data inválida não seja aceita ([#180](https://github.com/sdkgen/sdkgen/pull/180)).
- Atualização de dependências.