### PR TITLE
fix: playground regex

### DIFF
--- a/node-runtime/src/http-server.ts
+++ b/node-runtime/src/http-server.ts
@@ -111,7 +111,7 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
       res.end();
     });
 
-    this.addHttpHandler("GET", /^\/playground/u, (req, res) => {
+    this.addHttpHandler("GET", /^\/playground.*/u, (req, res) => {
       if (!this.introspection) {
         res.statusCode = 404;
         res.end();


### PR DESCRIPTION
Previously `addHttpHandler` accepted a regexp with a partial match. Since 1.5.3 the regex must match the whole path.