### PR TITLE
feat: Add content-type "application/sdkgen" from targets to avoid conflict with `@rest` calls

### DIFF
--- a/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
+++ b/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
@@ -210,7 +210,7 @@ open class SdkgenHttpClient(
     @SuppressLint("HardwareIds")
     private fun makeDeviceObj(): JsonObject {
         return JsonObject().apply {
-            addProperty("id", getDeviceId())    
+            addProperty("id", getDeviceId())
             addProperty("fingerprint", Settings.Secure.getString(applicationContext.contentResolver, Settings.Secure.ANDROID_ID))
             addProperty("language", language())
             add("platform", JsonObject().apply {
@@ -255,7 +255,7 @@ open class SdkgenHttpClient(
 
             val request = Request.Builder()
                 .url("$baseUrl${if (baseUrl.last() == '/') "" else "/"}$functionName")
-                .post(body.toString().toRequestBody("application/json; charset=utf-8".toMediaType()))
+                .post(body.toString().toRequestBody("application/sdkgen".toMediaType()))
                 .build()
 
             val call = httpClient.newCall(request)

--- a/browser-runtime/src/http-client.ts
+++ b/browser-runtime/src/http-client.ts
@@ -87,6 +87,7 @@ export class SdkgenHttpClient {
     const encodedRet = await new Promise<unknown>((resolve, reject) => {
       const req = new XMLHttpRequest();
 
+      req.setRequestHeader("Content-Type", "application/sdkgen");
       req.open("POST", `${this.baseUrl}/${functionName}`);
 
       req.onreadystatechange = () => {

--- a/dart-runtime/lib/http_client.dart
+++ b/dart-runtime/lib/http_client.dart
@@ -26,7 +26,9 @@ class SdkgenErrorWithData<T> implements Exception {
 class SdkgenHttpClient {
   Uri baseUrl;
   Map<String, dynamic> extra = <String, dynamic>{};
-  Map<String, String> headers = <String, String>{};
+  Map<String, String> headers = <String, String>{
+    "Content-Type": "application/sdkgen",
+  };
   Map<String, Object> typeTable;
   Map<String, FunctionDescription> fnTable;
   Map<String, SdkgenErrorDescription> errTable;

--- a/node-runtime/src/http-client.ts
+++ b/node-runtime/src/http-client.ts
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-promise-reject-errors */
 import { randomBytes } from "crypto";
 import { request as httpRequest } from "http";
-import { request as httpsRequest } from "https";
+import { request as httpsRequest, RequestOptions } from "https";
 import { hostname } from "os";
 import { URL } from "url";
 
@@ -51,11 +51,14 @@ export class SdkgenHttpClient {
       version: 3,
     });
 
-    const options = {
+    const options: RequestOptions = {
       hostname: this.baseUrl.hostname,
       method: "POST",
       path: this.baseUrl.pathname,
       port: this.baseUrl.port,
+      headers: {
+        "content-type": "application/sdkgen",
+      }
     };
 
     const encodedRet = await new Promise<unknown>((resolve, reject) => {

--- a/node-runtime/src/http-server.ts
+++ b/node-runtime/src/http-server.ts
@@ -639,12 +639,14 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
       path = path.slice(this.ignoredUrlPrefix.length);
     }
 
-    const externalHandler = this.findBestHandler(path, req);
+    if (!req.headers["content-type"]?.match(/application\/sdkgen/iu)) {
+      const externalHandler = this.findBestHandler(path, req);
 
-    if (externalHandler) {
-      this.log(`HTTP ${req.method} ${path}${query ? `?${query}` : ""}`);
-      externalHandler.handler(req, res, body);
-      return;
+      if (externalHandler) {
+        this.log(`HTTP ${req.method} ${path}${query ? `?${query}` : ""}`);
+        externalHandler.handler(req, res, body);
+        return;
+      }
     }
 
     res.setHeader("Content-Type", "application/json; charset=utf-8");


### PR DESCRIPTION
```
@rest POST /something
fn something(): string
```

When adding a `@rest` annotation with POST and the path being the same as the function name, the generated targets will end up calling the rest handler when trying to call the normal function. This patch prevents it by adding an opcional `Content-Type: application/sdkgen`. When the server receives it, it will ignore `@rest` options.