### PR TITLE
fix: support all valid header names

### DIFF
--- a/parser/spec/parser.spec.ts
+++ b/parser/spec/parser.spec.ts
@@ -556,6 +556,45 @@ describe(Parser, () => {
 
     expectParses(
       `
+        @rest POST /insertCustomerLead [header api_key: {apiKey}] [header api_secret: {apiSecret}] [body {customerLead}]
+        fn insertCustomerLead(customerLead: string, apiKey: bigint, apiSecret: string)
+      `,
+      {
+        annotations: {
+          "fn.insertCustomerLead": [
+            {
+              type: "rest",
+              value: {
+                bodyVariable: "customerLead",
+                headers: [
+                  ["api_key", "apiKey"],
+                  ["api_secret", "apiSecret"],
+                ],
+                method: "POST",
+                path: "/insertCustomerLead",
+                pathVariables: [],
+                queryVariables: [],
+              },
+            },
+          ],
+        },
+        errors: ["Fatal"],
+        functionTable: {
+          insertCustomerLead: {
+            args: {
+              customerLead: "string",
+              apiKey: "bigint",
+              apiSecret: "string",
+            },
+            ret: "void",
+          },
+        },
+        typeTable: {},
+      },
+    );
+
+    expectParses(
+      `
         type NewUser {
             name: string
         }

--- a/parser/src/restparser.ts
+++ b/parser/src/restparser.ts
@@ -3,7 +3,8 @@ import { parse as pathParse } from "path";
 import { RestAnnotation } from "./ast";
 
 function scanHeaders(text: string) {
-  const headerRegex = /\[header (?<header>[\w-]+): \{(?<name>\w+)\}\]/gu;
+  // Header name: https://tools.ietf.org/html/rfc2616#section-4.2
+  const headerRegex = /\[header (?<header>[^()<>@,;:\\"/[\]?={}\s\t]+): \{(?<name>\w+)\}\]/gu;
   const headers = new Map<string, string>();
 
   let match: RegExpExecArray | null;


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc2616#section-4.2, header names can have much more than only letters, numbers and dashes. Underscore `_` must be supported, for example.

![image](https://user-images.githubusercontent.com/546954/116718201-19f8b500-a9b0-11eb-9523-eed7fbbef104.png)

![image](https://user-images.githubusercontent.com/546954/116718167-11a07a00-a9b0-11eb-80fa-43b364a3bbb3.png)
