### PR TITLE
feat: allow parser to be usable from browser

### DIFF
--- a/parser/package.json
+++ b/parser/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@cubos/eslint-config": "^1.0.532516",
     "@types/jest": "^26.0.23",
-    "@types/node": "^15.12.4",
     "jest": "^27.0.5",
     "ts-jest": "^27.0.3",
     "typescript": "^4.3.4"

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -73,7 +73,7 @@ export class Parser {
   private warnings: string[] = [];
 
   // eslint-disable-next-line
-  constructor(source: Lexer | string, private readFileSync = require("fs").readFileSync as typeof import("fs")["readFileSync"]) {
+  constructor(source: Lexer | string, private readFileSync = require("fs").readFileSync as (path: string) => {toString(): string}) {
     if (source instanceof Lexer) {
       this.lexers = [source];
     } else {

--- a/parser/src/restparser.ts
+++ b/parser/src/restparser.ts
@@ -1,5 +1,3 @@
-import { parse as pathParse } from "path";
-
 import { RestAnnotation } from "./ast";
 
 function scanHeaders(text: string) {
@@ -51,22 +49,19 @@ export function parseRestAnnotation(text: string): RestAnnotation {
     throw new Error(`Unsupported method '${method}'`);
   }
 
-  const parsedPath = pathParse(fragments[1]);
+  // eslint-disable-next-line prefer-destructuring
+  let path = fragments[1];
 
-  if (parsedPath.root !== "/") {
+  if (!path.startsWith("/")) {
     throw new Error(`Invalid path`);
-  }
-
-  if (parsedPath.dir === "/") {
-    parsedPath.dir = "";
   }
 
   let queryVariables: string[] = [];
 
-  if (parsedPath.base.includes("?")) {
-    const [base, ...queryArray] = parsedPath.base.split("?");
+  if (path.includes("?")) {
+    const [base, ...queryArray] = path.split("?");
 
-    parsedPath.base = base;
+    path = base;
     const query = queryArray.join("?");
 
     if (!/^\{\w+\}(?:&\{\w+\})*$/u.test(query)) {
@@ -76,7 +71,6 @@ export function parseRestAnnotation(text: string): RestAnnotation {
     queryVariables = scanVariables(query);
   }
 
-  const path = `${parsedPath.dir}/${parsedPath.base}`;
   const pathVariables = scanVariables(path);
 
   const remaining = fragments.slice(2).join(" ");


### PR DESCRIPTION
Now `@sdkgen/parser` can be used from the Browser without Node imports.