### PR TITLE
fix(dart-runtime): use flutter window view

### DIFF
--- a/dart-runtime/lib/deviceinfo_io.dart
+++ b/dart-runtime/lib/deviceinfo_io.dart
@@ -10,9 +10,8 @@ Future<Map<String, Object?>> getDeviceInfo(String deviceId) async {
     // ignore: empty_catches
   } catch (e) {}
 
-  final window = PlatformDispatcher.instance.views
-      .whereType<SingletonFlutterWindow>()
-      .first;
+  final window =
+      PlatformDispatcher.instance.views.whereType<FlutterWindow>().first;
   final screenSize = window.physicalSize / window.devicePixelRatio;
 
   final platform = {


### PR DESCRIPTION
Searching `SingletonFlutterWindow` on `views` list causes `sdkgen_runtime` to fail on `makeRequest` calls