### PR TITLE
Fix: setRequestHeader should be called after open()

### DIFF
--- a/browser-runtime/src/http-client.ts
+++ b/browser-runtime/src/http-client.ts
@@ -88,8 +88,8 @@ export class SdkgenHttpClient {
     const encodedRet = await new Promise<unknown>((resolve, reject) => {
       const req = new XMLHttpRequest();
 
-      req.setRequestHeader("Content-Type", "application/sdkgen");
       req.open("POST", `${this.baseUrl}/${functionName}`);
+      req.setRequestHeader("Content-Type", "application/sdkgen");
 
       req.onreadystatechange = () => {
         if (req.readyState !== 4) {


### PR DESCRIPTION
Isso estava fazendo crashar as requisições dentro do eval()

```
DOMException: XMLHttpRequest.setRequestHeader: XMLHttpRequest state must be OPENED.
    makeRequest http-client.js:142
```

O motivo de ter funcionado assim até agora, eu não sei :joy: