### PR TITLE
Remove console.error

### DIFF
--- a/browser-runtime/src/http-client.ts
+++ b/browser-runtime/src/http-client.ts
@@ -122,7 +122,6 @@ export class SdkgenHttpClient {
 
       req.send(JSON.stringify(request));
     }).catch((error: object) => {
-      console.error(error);
       this.errorHook(error, functionName, args);
       if (has(error, "type") && has(error, "message") && typeof error.type === "string" && typeof error.message === "string") {
         const errClass = this.errClasses[error.type];


### PR DESCRIPTION
sdkgen shouldn't dump stuff to console during runtime, the devs should decide if errors should be logged or not