### PR TITLE
fix: iOS device model

### DIFF
--- a/dart-runtime/lib/deviceinfo_io.dart
+++ b/dart-runtime/lib/deviceinfo_io.dart
@@ -28,13 +28,16 @@ Future<Map<String, Object?>> getDeviceInfo(String deviceId) async {
 
   if (Platform.isAndroid) {
     final androidInfo = await deviceInfo.androidInfo;
-    platform['model'] = androidInfo.model; // Ex: SM-1234
-    platform['brand'] = androidInfo.brand; // Ex: Samsung
+    platform['model'] = androidInfo.model; // Ex: 'SM-G973F' for Samsung S10
+    platform['brand'] = androidInfo.brand; // Ex: 'Samsung'
     platform['version'] = androidInfo.version.release; // 10
     platform['sdkVersion'] = androidInfo.version.sdkInt; // 29
   } else if (Platform.isIOS) {
     final iosInfo = await deviceInfo.iosInfo;
-    platform['model'] = iosInfo.name; // Ex: iPhone 11 Pro Max
+    // Ex: 'iPhone7,1' for iPhone 6 Plus
+    // List of possible hardware type strings for iOS:
+    // https://gist.github.com/adamawolf/3048717
+    platform['model'] = iosInfo.utsname.machine;
     platform['brand'] = 'Apple';
     platform['version'] = iosInfo.systemVersion; // 13.1
   }


### PR DESCRIPTION
Today, the ios model returns `iosInfo.name` which can be, for example: "iPhone de Danilo". This PR fixes that, changing the model to be specific of each iPhone hardware, using the `utsname.machine` field.

This [repository](https://gist.github.com/adamawolf/3048717) lists the possible `utsname.machine` according to each Apple's product name (E.g: 'iPhone7,1' for iPhone 6 Plus).

** Tasks ** 
- [x] fix: iOS device model
- [x] docs: better comment android devices