### PR TITLE
refact: getDeviceTypeString

### DIFF
--- a/dart-runtime/lib/deviceinfo_io.dart
+++ b/dart-runtime/lib/deviceinfo_io.dart
@@ -50,21 +50,5 @@ Future<Map<String, Object?>> getDeviceInfo(String deviceId) async {
 }
 
 String _getDeviceTypeString() {
-  if (kIsWeb) {
-    return 'web';
-  } else if (Platform.isAndroid) {
-    return 'android';
-  } else if (Platform.isFuchsia) {
-    return 'fuchsia';
-  } else if (Platform.isIOS) {
-    return 'ios';
-  } else if (Platform.isLinux) {
-    return 'linux';
-  } else if (Platform.isMacOS) {
-    return 'macos';
-  } else if (Platform.isWindows) {
-    return 'windows';
-  } else {
-    return 'flutter';
-  }
+  return kIsWeb ? 'web' : Platform.operatingSystem;
 }


### PR DESCRIPTION
This refactoring reduces an unnecessary boilerplate on `_getDeviceTypeString` function, using an method already provided by the Flutter's `Platform`.