### PR TITLE
Fix playground docs release CI

### DIFF
--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -11,6 +11,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.x"
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+          registry-url: https://registry.npmjs.org
       - run: pip install mkdocs-material
       - run: sed -i -e "s/sdkgen.github.io/sdkgen.github.io\/dev/g" mkdocs.yml
       - run: mkdocs build

--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -10,6 +10,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.x"
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+          registry-url: https://registry.npmjs.org
       - run: pip install mkdocs-material
       - run: mkdocs build
       - run: git clone --depth 1 -b master https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/sdkgen/sdkgen.github.io.git


### PR DESCRIPTION
Action `setup-node` was missing and it was using ubuntu-latest's node, which seems to require root.