### PR TITLE
fix: show correct error schema on swagger

### DIFF
--- a/node-runtime/src/swagger.ts
+++ b/node-runtime/src/swagger.ts
@@ -375,17 +375,26 @@ export function setupSwagger<ExtraContextT>(server: SdkgenHttpServer<ExtraContex
                   content: {
                     "application/json": {
                       schema: {
-                        properties: {
-                          message: {
-                            type: "string",
-                          },
-                          type: {
-                            enum: server.apiConfig.ast.errors,
-                            type: "string",
-                          },
-                        },
-                        required: ["type", "message"],
-                        type: "object",
+                        anyOf: [
+                          server.apiConfig.ast.errors.map(error => ({
+                            properties: {
+                              message: {
+                                type: "string",
+                              },
+                              type: {
+                                enum: [error.name],
+                                type: "string",
+                              },
+                              ...(error.dataType instanceof VoidPrimitiveType
+                                ? {}
+                                : {
+                                    data: typeToSchema(definitions, error.dataType),
+                                  }),
+                            },
+                            required: ["type", "message"],
+                            type: "object",
+                          })),
+                        ],
                       },
                     },
                   },


### PR DESCRIPTION
Previously the AST node was being inserted into the swagger example. Now it shows the correct information.

![image](https://user-images.githubusercontent.com/546954/139139275-89d39363-fbd1-4691-a999-4cbbc44eced3.png)
