### PR TITLE
Add function to set OkhttpClient on SdkgenHttpClient.kt

### DIFF
--- a/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
+++ b/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
@@ -347,7 +347,7 @@ open class SdkgenHttpClient(
         }
     }
 
-    fun setHttpClient(client: OkHttpClient){
+    fun setHttpClient(client: OkHttpClient) {
         httpClient = client
     }
 }

--- a/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
+++ b/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
@@ -120,7 +120,7 @@ open class SdkgenHttpClient(
     private val random = Random()
     private val hexArray = "0123456789abcdef".toCharArray()
     private val gson = Gson()
-    private val httpClient = OkHttpClient.Builder()
+    private var httpClient = OkHttpClient.Builder()
         .connectTimeout(5, TimeUnit.MINUTES)
         .readTimeout(5, TimeUnit.MINUTES)
         .callTimeout(5, TimeUnit.MINUTES)
@@ -345,5 +345,9 @@ open class SdkgenHttpClient(
                 )
             )
         }
+    }
+
+    fun setHttpClient(client: OkHttpClient){
+        httpClient = client
     }
 }


### PR DESCRIPTION
The ideia is to allow SdkgenHttpClient use and external customized OkHttpClient. This way it will be possible to create, by example, a customized OKhttpClient with an Interceptor to implement a CircuitBreaker.
The changes for this PR is only add a set modifier and change the acess modifier from httpClient to var.