### PR TITLE
[Dart runtime]: replace package `device_info` to `device_info_plus`

### DIFF
--- a/dart-runtime/lib/deviceinfo_io.dart
+++ b/dart-runtime/lib/deviceinfo_io.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 import 'dart:ui';
 import 'package:flutter/foundation.dart';
-import 'package:device_info/device_info.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:package_info/package_info.dart';
 
 Future<Map<String, Object?>> getDeviceInfo(String deviceId) async {

--- a/dart-runtime/pubspec.yaml
+++ b/dart-runtime/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   convert: ^3.0.0
-  device_info: ^2.0.0
+  device_info_plus: ^3.1.1
   equatable: ^2.0.0
   http: ^0.13.0
   package_info: ^2.0.0


### PR DESCRIPTION
This PR resolves the issue #579. Please, test it before merging.