### PR TITLE
Allow access to SdkgenHttpClient members on advanced editor

### DIFF
--- a/playground/src/app/sdkgen.service.ts
+++ b/playground/src/app/sdkgen.service.ts
@@ -281,6 +281,10 @@ export class SdkgenService {
 
     return new Proxy(clientInstance, {
       get: (target, name) => {
+        if (["baseUrl", "extra", "successHook", "errorHook", "makeRequest"].includes(name.toString())) {
+          return clientInstance[name.toString() as keyof SdkgenHttpClient];
+        }
+
         return async (args: any) => clientInstance.makeRequest(name.toString(), args);
       },
     });

--- a/playground/src/app/tab-editor/tab-editor.component.ts
+++ b/playground/src/app/tab-editor/tab-editor.component.ts
@@ -71,12 +71,21 @@ export class TabEditorComponent implements OnInit, OnDestroy {
   }
 
   patchBrowserClientSource(source: string) {
+    const additionalMembers = `
+      baseUrl: string;
+      extra = new Map<string, any>();
+      successHook: (result: any, name: string, args: any) => void = () => undefined;
+      errorHook: (result: any, name: string, args: any) => void = () => undefined;
+      async makeRequest(functionName: string, args: unknown): Promise<any>;
+    `;
+
     return `declare namespace sdkgen {\n${source
       .substring(95, source.indexOf("const errClasses"))
       .replace(/ extends SdkgenError/g, " extends Error")
       .replace(/ extends SdkgenHttpClient/g, "")
       .replace(/{ return this.makeRequest\(.*$/gm, "")
-      .replace(/ {\n {8}super\(baseUrl, astJson, errClasses\);\n {4}}/g, "")}\n}\n`;
+      .replace(/ {\n {8}super\(baseUrl, astJson, errClasses\);\n {4}}/g, "")
+      .replace("constructor(", `${additionalMembers}\nconstructor(`)}\n}\n`;
   }
 
   async run() {


### PR DESCRIPTION
This will allow users to set extras and hooks on advanced editor, just like a traditional SdkgenHttpClient instance

![image](https://user-images.githubusercontent.com/10081640/149217805-a7774686-32f3-4e78-9b5f-4f380b3ba79c.png)
