### PR TITLE
fix: support tasks on net5 in Fsharp Generator

### DIFF
--- a/fsharp-generator/src/fsharp-server.ts
+++ b/fsharp-generator/src/fsharp-server.ts
@@ -12,7 +12,10 @@ open System.Threading.Tasks
 open System.Text.Json
 open System
 open System.Globalization
+#if NET5_0
+// To use tasks as computation expression in .NET 5 install https://www.nuget.org/packages/TaskBuilder.fs/
 open FSharp.Control.Tasks.V2.ContextInsensitive
+#endif
 `;
 
   for (const error of ast.errors) {


### PR DESCRIPTION
F# suporta tasks de forma nativa na versão 6, porém para utilizar na versão 5 é necessário instalar o [TaskBuilder.fs](https://www.nuget.org/packages/TaskBuilder.fs/) como dependência; 