### PR TITLE
Implementation-agnostic server specs

### DIFF
--- a/node-runtime/package.json
+++ b/node-runtime/package.json
@@ -37,7 +37,8 @@
     "spec.ts": "^1.1.3",
     "ts-jest": "^27.0.5",
     "type-fest": "^2.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.3.5",
+    "yaml": "^1.10.2"
   },
   "jest": {
     "transform": {

--- a/node-runtime/spec/server-spec/server.spec.ts
+++ b/node-runtime/spec/server-spec/server.spec.ts
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { readFileSync, unlinkSync, writeFileSync } from "fs";
+
+import { Parser } from "@sdkgen/parser";
+import { generateNodeServerSource } from "@sdkgen/typescript-generator";
+import type { AxiosRequestHeaders, Method } from "axios";
+import axios from "axios";
+import YAML from "yaml";
+
+import type { Context } from "../../src";
+import { SdkgenHttpServer } from "../../src";
+
+const ast = new Parser(`${__dirname}/../../../server-spec-data/api.sdkgen`).parse();
+
+writeFileSync(`${__dirname}/api.ts`, generateNodeServerSource(ast).replace(/@sdkgen\/node-runtime/gu, "../../src"));
+const { api } = require(`${__dirname}/api.ts`);
+
+unlinkSync(`${__dirname}/api.ts`);
+
+api.fn.add = (_ctx: Context, { first, second }: { first: number; second: number }) => {
+  return first + second;
+};
+
+api.fn.concat = (_ctx: Context, { first, second }: { first: number; second: string }) => {
+  return `${first}${second}`;
+};
+
+interface Feature {
+  name: string;
+  tests: Array<{
+    name: string;
+    request: {
+      method: Method;
+      headers?: AxiosRequestHeaders;
+      path: string;
+      body: unknown;
+    };
+    response: {
+      status?: number;
+      body: unknown;
+      headers?: Record<string, string>;
+    };
+  }>;
+}
+
+const testData: Feature[] = YAML.parse(readFileSync(`${__dirname}/../../../server-spec-data/tests.yaml`, "utf8"));
+
+const server = new SdkgenHttpServer(api, {});
+
+server.log = () => {};
+
+beforeAll(async () => {
+  await server.listen(34368);
+});
+
+afterAll(async () => {
+  await server.close();
+});
+
+for (const feature of testData) {
+  describe(feature.name, () => {
+    for (const test of feature.tests) {
+      it(test.name, async () => {
+        const result = await axios.request({
+          method: test.request.method,
+          baseURL: "http://localhost:34368",
+          url: test.request.path,
+          data: test.request.body,
+          headers: test.request.headers,
+          validateStatus: () => true,
+          transformResponse: [],
+        });
+
+        expect(result.status).toBe(test.response.status ?? 200);
+        if (typeof test.response.body === "object") {
+          expect(JSON.parse(result.data)).toMatchObject(test.response.body as object);
+        } else {
+          expect(result.data).toBe(test.response.body);
+        }
+
+        if (test.response.headers) {
+          for (const [name, value] of Object.entries(test.response.headers)) {
+            expect(result.headers[name]).toBe(value);
+          }
+        }
+      });
+    }
+  });
+}

--- a/server-spec-data/api.sdkgen
+++ b/server-spec-data/api.sdkgen
@@ -1,0 +1,10 @@
+@rest POST /add?{first}&{second}
+fn add(first: int, second: int): int
+
+@rest GET /concat1/{first}/{second}
+@rest GET /concat2?{first}&{second}
+@rest GET /concat3?{first} [header x-second: {second}]
+@rest POST /concat4 [body {first}] [header x-second: {second}]
+@rest POST /concat5 [body {second}] [header x-first: {first}]
+@rest POST /concat6?{first}&{second}
+fn concat(first: int, second: string): string

--- a/server-spec-data/tests.yaml
+++ b/server-spec-data/tests.yaml
@@ -1,0 +1,91 @@
+- name: Core Protocol
+  tests:
+    - name: Simple 'add' call
+      request:
+        method: POST
+        path: /
+        body:
+          name: add
+          args:
+            first: 1
+            second: 2
+      response:
+        body:
+          result: 3
+    - name: Simple 'add' call, inverting argument order
+      request:
+        method: POST
+        path: /
+        body:
+          name: add
+          args:
+            second: 2
+            first: 1
+      response:
+        body:
+          result: 3
+    - name: Simple 'add' call, with extra arguments
+      request:
+        method: POST
+        path: /
+        body:
+          name: add
+          args:
+            first: 1
+            second: 2
+            whatever: "123"
+      response:
+        body:
+          result: 3
+
+- name: REST
+  tests:
+    - name: Simple 'add' call
+      request:
+        method: POST
+        path: /add?first=1&second=2
+      response:
+        status: 200
+        headers:
+          content-type: text/plain
+        body: "3"
+    - name: Simple 'add' call with accept header
+      request:
+        method: POST
+        path: /add?first=1&second=2
+        headers:
+          accept: application/json
+      response:
+        status: 200
+        headers:
+          content-type: application/json
+        body: "3"
+    - name: Concat
+      request:
+        method: GET
+        path: /concat1/1/aa
+      response:
+        status: 200
+        headers:
+          content-type: text/plain
+        body: "1aa"
+    - name: Concat with accept header
+      request:
+        method: GET
+        path: /concat1/1/aa
+        headers:
+          accept: application/json
+      response:
+        status: 200
+        headers:
+          content-type: application/json
+        body: "\"1aa\""
+    - name: Concat with trailing slash
+      request:
+        method: GET
+        path: /concat1/1/aa/
+      response:
+        status: 200
+        headers:
+          content-type: text/plain
+        body: "1aa"


### PR DESCRIPTION
We need a better description of the sdkgen protocol as well as better tests for edge cases. Right now we have two server implementations: Node.js and F#. They differ in some aspects and the Node.js is regarded as the reference implementation.

The goal here is to add a set of implementation-agnostic tests that will serve as a specification on how any server implementation should behave.

This is in the early stages.