### PR TITLE
Fix: Better handing of repeated identical types

### DIFF
--- a/parser/spec/parser.spec.ts
+++ b/parser/spec/parser.spec.ts
@@ -300,6 +300,32 @@ describe(Parser, () => {
         },
       },
     );
+
+    expectParses(
+      `
+        type Test {
+          foo: enum { bar baz }
+        }
+
+        type Test2 {
+          ...Test
+        }
+      `,
+      {
+        annotations: {},
+        errors: ["Fatal"],
+        functionTable: {},
+        typeTable: {
+          Test: {
+            foo: "TestFoo",
+          },
+          Test2: {
+            foo: "TestFoo",
+          },
+          TestFoo: ["bar", "baz"],
+        },
+      },
+    );
   });
 
   test("handles functions with arguments", () => {

--- a/parser/src/json.ts
+++ b/parser/src/json.ts
@@ -126,6 +126,10 @@ export function astToJson(ast: AstRoot): AstJson {
   }
 
   for (const { name, fields } of ast.structTypes) {
+    if (name in typeTable) {
+      throw new Error(`Duplicate struct type ${name}`);
+    }
+
     typeTable[name] = {};
     const obj = typeTable[name] as Record<string, TypeDescription>;
 
@@ -144,6 +148,10 @@ export function astToJson(ast: AstRoot): AstJson {
   }
 
   for (const { name, values } of ast.enumTypes) {
+    if (name in typeTable) {
+      throw new Error(`Duplicate enum type ${name}`);
+    }
+
     typeTable[name] = values.map(v => {
       if (!v.struct) {
         return v.value;

--- a/parser/src/semantic/02_give_struct_and_enum_names.ts
+++ b/parser/src/semantic/02_give_struct_and_enum_names.ts
@@ -1,46 +1,57 @@
-import type { AstNode, Type } from "../ast";
+import type { AstNode } from "../ast";
 import { EnumValue, FunctionOperation, EnumType, ErrorNode, Field, StructType, TypeDefinition } from "../ast";
-import { SemanticError, Visitor } from "./visitor";
+import { Transformer } from "./transformer";
+import { SemanticError } from "./visitor";
 
-export class GiveStructAndEnumNamesVisitor extends Visitor {
+export class GiveStructAndEnumNamesTransformer extends Transformer {
   path: string[] = [];
 
-  names = new Map<string, { type: Type; path: string[] }>();
+  names = new Map<string, { type: StructType | EnumType; path: string[] }>();
 
-  visit(node: AstNode): void {
+  transform<T extends AstNode>(node: T): T {
     if (node instanceof TypeDefinition) {
       this.path = [node.name];
-      super.visit(node);
+      return super.transform(node);
     } else if (node instanceof ErrorNode) {
       this.path = [`${node.name}Data`];
-      super.visit(node);
+      return super.transform(node);
     } else if (node instanceof FunctionOperation) {
       this.path = [node.name];
-      super.visit(node);
+      return super.transform(node);
     } else if (node instanceof Field) {
-      this.path.push(node.name);
-      super.visit(node);
-      this.path.pop();
+      try {
+        this.path.push(node.name);
+        return super.transform(node);
+      } finally {
+        this.path.pop();
+      }
     } else if (node instanceof EnumValue) {
-      this.path.push(node.value);
-      super.visit(node);
-      this.path.pop();
+      try {
+        this.path.push(node.value);
+        return super.transform(node);
+      } finally {
+        this.path.pop();
+      }
     } else if (node instanceof StructType || node instanceof EnumType) {
       node.name = this.path.map(s => s[0].toUpperCase() + s.slice(1)).join("");
       const previous = this.names.get(node.name);
 
-      if (previous && JSON.stringify(previous.type) !== JSON.stringify(node)) {
-        throw new SemanticError(
-          `The name of the type '${this.path.join(".")}' at ${node.location} will conflict with '${previous.path.join(".")}' at ${
-            previous.type.location
-          }`,
-        );
+      if (previous) {
+        if (previous.type.constructor !== node.constructor || JSON.stringify(previous.type) !== JSON.stringify(node)) {
+          throw new SemanticError(
+            `The name of the type '${this.path.join(".")}' at ${node.location} will conflict with '${previous.path.join(".")}' at ${
+              previous.type.location
+            }`,
+          );
+        }
+
+        return previous.type as unknown as T;
       }
 
       this.names.set(node.name, { path: [...this.path], type: node });
-      super.visit(node);
+      return super.transform(node);
     } else {
-      super.visit(node);
+      return super.transform(node);
     }
   }
 }

--- a/parser/src/semantic/08_collect_struct_and_enum_types.ts
+++ b/parser/src/semantic/08_collect_struct_and_enum_types.ts
@@ -12,4 +12,11 @@ export class CollectStructAndEnumTypesVisitor extends Visitor {
       this.root.enumTypes.push(node);
     }
   }
+
+  process(): void {
+    super.process();
+
+    this.root.structTypes = [...new Set(this.root.structTypes)];
+    this.root.enumTypes = [...new Set(this.root.enumTypes)];
+  }
 }

--- a/parser/src/semantic/08_collect_struct_and_enum_types.ts
+++ b/parser/src/semantic/08_collect_struct_and_enum_types.ts
@@ -3,20 +3,21 @@ import { EnumType, StructType } from "../ast";
 import { Visitor } from "./visitor";
 
 export class CollectStructAndEnumTypesVisitor extends Visitor {
+  visited = new Set<AstNode>();
+
   visit(node: AstNode): void {
     super.visit(node);
+
+    if (this.visited.has(node)) {
+      return;
+    }
+
+    this.visited.add(node);
 
     if (node instanceof StructType) {
       this.root.structTypes.push(node);
     } else if (node instanceof EnumType) {
       this.root.enumTypes.push(node);
     }
-  }
-
-  process(): void {
-    super.process();
-
-    this.root.structTypes = [...new Set(this.root.structTypes)];
-    this.root.enumTypes = [...new Set(this.root.enumTypes)];
   }
 }

--- a/parser/src/semantic/analyser.ts
+++ b/parser/src/semantic/analyser.ts
@@ -1,7 +1,7 @@
 import type { AstRoot } from "../ast";
 import { ErrorNode, VoidPrimitiveType } from "../ast";
 import { CheckMultipleDeclarationVisitor } from "./01_check_multiple_declaration";
-import { GiveStructAndEnumNamesVisitor } from "./02_give_struct_and_enum_names";
+import { GiveStructAndEnumNamesTransformer } from "./02_give_struct_and_enum_names";
 import { MatchTypeDefinitionsVisitor } from "./03_match_type_definitions";
 import { CheckDontReturnSecretVisitor } from "./04_check_dont_return_secret";
 import { ExpandSpreadsVisitor } from "./05_expand_spreads";
@@ -16,7 +16,7 @@ export function analyse(root: AstRoot): void {
   }
 
   new CheckMultipleDeclarationVisitor(root).process();
-  new GiveStructAndEnumNamesVisitor(root).process();
+  new GiveStructAndEnumNamesTransformer(root).process();
   new MatchTypeDefinitionsVisitor(root).process();
   new CheckDontReturnSecretVisitor(root).process();
   new ExpandSpreadsVisitor(root).process();

--- a/parser/src/semantic/transformer.ts
+++ b/parser/src/semantic/transformer.ts
@@ -1,0 +1,41 @@
+import type { AstNode, AstRoot } from "../ast";
+import { EnumValue, EnumType, Spread, FunctionOperation, ArrayType, ErrorNode, Field, OptionalType, StructType, TypeDefinition } from "../ast";
+
+export class SemanticError extends Error {}
+
+export abstract class Transformer {
+  constructor(protected root: AstRoot) {}
+
+  process(): void {
+    this.root.errors = this.root.errors.map(x => this.transform(x));
+    this.root.typeDefinitions = this.root.typeDefinitions.map(x => this.transform(x));
+    this.root.operations = this.root.operations.map(x => this.transform(x));
+  }
+
+  transform<T extends AstNode>(node: T): T {
+    if (node instanceof FunctionOperation) {
+      node.args = node.args.map(x => this.transform(x));
+      node.fieldsAndSpreads = node.fieldsAndSpreads.map(x => this.transform(x));
+      node.returnType = this.transform(node.returnType);
+    } else if (node instanceof Field || node instanceof TypeDefinition) {
+      node.type = this.transform(node.type);
+    } else if (node instanceof StructType) {
+      node.fields = node.fields.map(x => this.transform(x));
+      node.fieldsAndSpreads = node.fieldsAndSpreads.map(x => this.transform(x));
+    } else if (node instanceof EnumType) {
+      node.values = node.values.map(x => this.transform(x));
+    } else if (node instanceof EnumValue) {
+      if (node.struct) {
+        node.struct = this.transform(node.struct);
+      }
+    } else if (node instanceof ArrayType || node instanceof OptionalType) {
+      node.base = this.transform(node.base);
+    } else if (node instanceof ErrorNode) {
+      node.dataType = this.transform(node.dataType);
+    } else if (node instanceof Spread) {
+      node.typeReference = this.transform(node.typeReference);
+    }
+
+    return node;
+  }
+}


### PR DESCRIPTION
This PR fixes three issues:

1. Detect duplicate types with the same name early on and throw an error. This prevents it from leaking into the codegen phase and generating invalid code with duplicated classes/interfaces.
2. If the same type is referred by multiple places of the AST (if it was inlined by the spread operator for example), it should not be duplicated, only one of them should be included.
3. If two types declared twice are identical they should be merged together and their parent nodes should be updated to point to the same type. Previously the duplication would be simply ignored.

Please review each of the commits separately. Their commit message explains each fix.