### PR TITLE
Allow user to override response's statusCode and headers

### DIFF
--- a/node-runtime/src/context.ts
+++ b/node-runtime/src/context.ts
@@ -1,4 +1,4 @@
-import type { IncomingHttpHeaders } from "http";
+import type { IncomingHttpHeaders, OutgoingHttpHeader } from "http";
 import type { Readable } from "stream";
 
 export interface ContextRequest {
@@ -32,7 +32,7 @@ export interface ContextReply {
 
 export interface ContextResponse {
   statusCode?: number;
-  headers?: Record<string, string>;
+  headers: Map<string, OutgoingHttpHeader>;
 }
 
 export interface Context {

--- a/node-runtime/src/context.ts
+++ b/node-runtime/src/context.ts
@@ -30,6 +30,12 @@ export interface ContextReply {
   result?: unknown;
 }
 
+export interface ContextResponse {
+  statusCode?: number;
+  headers?: Record<string, string>;
+}
+
 export interface Context {
   request: ContextRequest;
+  response: ContextResponse;
 }

--- a/node-runtime/src/http-server.ts
+++ b/node-runtime/src/http-server.ts
@@ -515,8 +515,8 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
             await this.executeRequest(request, (ctx, reply) => {
               try {
                 if (ctx?.response.headers) {
-                  for (const [headerName, headerValue] of Object.entries(ctx.response.headers)) {
-                    res.setHeader(headerName, headerValue);
+                  for (const [headerKey, headerValue] of ctx.response.headers.entries()) {
+                    res.setHeader(headerKey, headerValue);
                   }
                 }
 
@@ -764,7 +764,9 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
     const ctx: Context & ExtraContextT = {
       ...this.extraContext,
       request,
-      response: {},
+      response: {
+        headers: new Map(),
+      },
     };
 
     writeReply(ctx, await executeRequest(ctx, this.apiConfig));
@@ -1034,10 +1036,8 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
       res.statusCode = ctx.response.statusCode;
     }
 
-    if (ctx.response.headers) {
-      for (const [key, value] of Object.entries(ctx.response.headers)) {
-        res.setHeader(key, value);
-      }
+    for (const [headerKey, headerValue] of ctx.response.headers.entries()) {
+      res.setHeader(headerKey, headerValue);
     }
 
     switch (ctx.request.version) {

--- a/node-runtime/src/http-server.ts
+++ b/node-runtime/src/http-server.ts
@@ -514,7 +514,7 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
 
             await this.executeRequest(request, (ctx, reply) => {
               try {
-                if (ctx?.response.headers) {
+                if (ctx) {
                   for (const [headerKey, headerValue] of ctx.response.headers.entries()) {
                     res.setHeader(headerKey, headerValue);
                   }

--- a/node-runtime/src/http-server.ts
+++ b/node-runtime/src/http-server.ts
@@ -512,12 +512,25 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
               version: 3,
             };
 
-            await this.executeRequest(request, (_ctx, reply) => {
+            await this.executeRequest(request, (ctx, reply) => {
               try {
+                if (ctx?.response.headers) {
+                  for (const [headerName, headerValue] of Object.entries(ctx.response.headers)) {
+                    res.setHeader(headerName, headerValue);
+                  }
+                }
+
+                if (ctx?.response.statusCode) {
+                  res.statusCode = ctx.response.statusCode;
+                }
+
                 if (reply.error) {
                   const error = this.makeResponseError(reply.error);
 
-                  res.statusCode = error.type === "Fatal" ? 500 : 400;
+                  if (!ctx?.response.statusCode) {
+                    res.statusCode = error.type === "Fatal" ? 500 : 400;
+                  }
+
                   res.setHeader("content-type", "application/json");
                   res.write(JSON.stringify(error));
                   res.end();
@@ -533,7 +546,10 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
 
                   if (type instanceof OptionalType) {
                     if (reply.result === null) {
-                      res.statusCode = ann.method === "GET" ? 404 : 204;
+                      if (!ctx?.response.statusCode) {
+                        res.statusCode = ann.method === "GET" ? 404 : 204;
+                      }
+
                       res.end();
                       return;
                     }
@@ -748,6 +764,7 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
     const ctx: Context & ExtraContextT = {
       ...this.extraContext,
       request,
+      response: {},
     };
 
     writeReply(ctx, await executeRequest(ctx, this.apiConfig));
@@ -1013,6 +1030,16 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
 
     this.log(`${ctx.request.id} [${duration.toFixed(6)}s] ${ctx.request.name}() -> ${reply.error ? this.makeResponseError(reply.error).type : "OK"}`);
 
+    if (ctx.response.statusCode) {
+      res.statusCode = ctx.response.statusCode;
+    }
+
+    if (ctx.response.headers) {
+      for (const [key, value] of Object.entries(ctx.response.headers)) {
+        res.setHeader(key, value);
+      }
+    }
+
     switch (ctx.request.version) {
       case 1: {
         const response = {
@@ -1025,7 +1052,7 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
           result: reply.error ? null : reply.result,
         };
 
-        if (response.error) {
+        if (response.error && !ctx.response.statusCode) {
           res.statusCode = this.makeResponseError(response.error).type === "Fatal" ? 500 : 400;
         }
 
@@ -1044,7 +1071,7 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
           sessionId: ctx.request.extra.sessionId,
         };
 
-        if (response.error) {
+        if (response.error && !ctx.response.statusCode) {
           res.statusCode = this.makeResponseError(response.error).type === "Fatal" ? 500 : 400;
         }
 
@@ -1061,7 +1088,7 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
           result: reply.error ? null : reply.result,
         };
 
-        if (response.error) {
+        if (response.error && !ctx.response.statusCode) {
           res.statusCode = this.makeResponseError(response.error).type === "Fatal" ? 500 : 400;
         }
 


### PR DESCRIPTION
`Context` has now a `response` that allows users to, in any request (REST or sdkgen), override the `statusCode` and set headers.