### PR TITLE
fix: use `declare` keyword to override property type from parent class

### DIFF
--- a/typescript-generator/src/node-server.ts
+++ b/typescript-generator/src/node-server.ts
@@ -37,7 +37,7 @@ export { Fatal } from "@sdkgen/node-runtime";
   }
 
   code += `export class ApiConfig<ExtraContextT> extends BaseApiConfig<ExtraContextT> {
-    fn!: {${ast.operations
+    declare fn: {${ast.operations
       .map(
         op => `
         ${op.name}: (ctx: Context & ExtraContextT, args: {${op.args


### PR DESCRIPTION
This syntax is supported since TypeScript 3.7 and is required since ES2022 (or the current ESNext).

See https://github.com/microsoft/TypeScript/pull/33509 for extra details.

When overriding the type of a property from a parent class without setting an initial value, the keyword `declare` should be used to prevent the property from being initialized to undefined.

Replaces and closes #681.