### PR TITLE
feat: support multiple files as cli arguments

### DIFF
--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -17,7 +17,7 @@ import commandLineArgs from "command-line-args";
 import commandLineUsage from "command-line-usage";
 
 const optionDefinitions = [
-  { defaultOption: true, description: "Specifies the source file", name: "source" },
+  { defaultOption: true, description: "Specifies the source file", name: "sourcew", multiple: true },
   { alias: "o", description: "Specifies the output file", name: "output" },
   { alias: "t", description: "Specifies the target platform and language", name: "target" },
   { alias: "h", description: "Display this usage guide.", name: "help", type: Boolean },
@@ -25,7 +25,7 @@ const optionDefinitions = [
 
 export function buildCmd(argv: string[]): void {
   const options = commandLineArgs(optionDefinitions, { argv }) as {
-    source?: string;
+    sources?: string[];
     output?: string;
     target?: string;
     help?: boolean;
@@ -66,8 +66,8 @@ export function buildCmd(argv: string[]): void {
     process.exit(0);
   }
 
-  if (!options.source) {
-    console.error("Error: Missing 'source' option.");
+  if (!options.sources || options.sources.length === 0) {
+    console.error("Error: Missing 'sources' option.");
     process.exit(1);
   }
 
@@ -81,7 +81,7 @@ export function buildCmd(argv: string[]): void {
     process.exit(1);
   }
 
-  const ast = new Parser(options.source).parse();
+  const ast = new Parser(options.sources).parse();
 
   for (const warning of ast.warnings) {
     console.error(`WARNING: ${warning}`);

--- a/cli/src/build.ts
+++ b/cli/src/build.ts
@@ -17,7 +17,7 @@ import commandLineArgs from "command-line-args";
 import commandLineUsage from "command-line-usage";
 
 const optionDefinitions = [
-  { defaultOption: true, description: "Specifies the source file", name: "sourcew", multiple: true },
+  { defaultOption: true, description: "Specifies the source file", name: "sources", multiple: true },
   { alias: "o", description: "Specifies the output file", name: "output" },
   { alias: "t", description: "Specifies the target platform and language", name: "target" },
   { alias: "h", description: "Display this usage guide.", name: "help", type: Boolean },

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -79,7 +79,7 @@ export class Parser {
     throw "Not implemented";
   };
 
-  constructor(source: Lexer | string) {
+  constructor(source: Lexer | string | Array<Lexer | string>) {
     try {
       // eslint-disable-next-line
       this.readFileSync = require("fs").readFileSync;
@@ -87,11 +87,9 @@ export class Parser {
       // do nothing
     }
 
-    if (source instanceof Lexer) {
-      this.lexers = [source];
-    } else {
-      this.lexers = [new Lexer(this.readFileSync(source).toString(), source)];
-    }
+    const sources = Array.isArray(source) ? [...source].reverse() : [source];
+
+    this.lexers = sources.map(x => (x instanceof Lexer ? x : new Lexer(this.readFileSync(x).toString(), x)));
 
     this.nextToken();
   }


### PR DESCRIPTION
This makes it possible to do `sdkgen src/schemas/*.sdkgen -o src/generated/api.ts -t typescript_nodeserver`, including all files from a folder. Any shell glob pattern will work.