### PR TITLE
Add ctx.sessionData

### DIFF
--- a/node-runtime/src/context.ts
+++ b/node-runtime/src/context.ts
@@ -22,12 +22,14 @@ export interface ContextRequest {
     name: string;
     contents: Readable;
   }>;
+  sessionData: Record<string, string | undefined>;
 }
 
 export interface ContextReply {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error?: any;
   result?: unknown;
+  sessionData?: Record<string, string | null | undefined>;
 }
 
 export interface ContextResponse {
@@ -38,4 +40,8 @@ export interface ContextResponse {
 export interface Context {
   request: ContextRequest;
   response: ContextResponse;
+  sessionData: {
+    get(key: string): string | null;
+    set(key: string, value: string | null): void;
+  };
 }


### PR DESCRIPTION
This PR adds a key-value session storage that is kept on the client. This is how it works:

- In the beginning, the session storage is empty. No keys are defined.
- When the application makes a request, it sends the session data. In this case, nothing is sent.
- The API implementation might read keys from the session data or define new keys using `ctx.sessionData.get(key)` and `ctx.sessionData.set(key, value)`. If something new was defined, it is sent to the client in the response (only the diff is sent).
- The client receives the new values and stores them. In the next request, the new session data is sent.

This is especially useful to save a session token after log in. For example:

```
type User {
  name: string
}

fn logIn(email: string, password: string): User
fn getCurrentUser(): User
```

Implementation:

```ts
api.fn.logIn = async (ctx, {email, password}) => {
   // do login...
  ctx.sessionData.set("token", token);
  return user;
}

api.fn.getCurrentUser= async (ctx, {email, password}) => {
  const token = ctx.sessionData.get("token");
  if (!token) throw "not authenticated";
  return obtainUserFromToken(token);
}
```

This new feature mostly replaces the use cases for `extra` on the client-side.

- [x] Node server
- [ ] F# server
- [x] Node client
- [x] Browser client
- [ ] Flutter client
- [ ] Android client
- [ ] iOS client
- [ ] Playground