### PR TITLE
fix: The order of path arguments in a rest annotation should be kept unchanged.

### DIFF
--- a/parser/spec/parser.spec.ts
+++ b/parser/spec/parser.spec.ts
@@ -503,6 +503,9 @@ describe(Parser, () => {
 
         @rest GET /users/count?{since}&{until}
         fn userCount(since: date?, until: date?): uint
+
+        @rest GET /users/{userId}/addresses/{addressId}
+        fn userAddress(userId: string, addressId: string): string
       `,
       {
         annotations: {
@@ -545,6 +548,19 @@ describe(Parser, () => {
               },
             },
           ],
+          "fn.userAddress": [
+            {
+              type: "rest",
+              value: {
+                bodyVariable: null,
+                headers: [],
+                method: "GET",
+                path: "/users/{userId}/addresses/{addressId}",
+                pathVariables: ["userId", "addressId"],
+                queryVariables: [],
+              },
+            },
+          ],
         },
         errors: ["Fatal"],
         functionTable: {
@@ -564,6 +580,13 @@ describe(Parser, () => {
               until: "date?",
             },
             ret: "uint",
+          },
+          userAddress: {
+            args: {
+              userId: "string",
+              addressId: "string",
+            },
+            ret: "string",
           },
         },
         typeTable: {},

--- a/parser/src/json.ts
+++ b/parser/src/json.ts
@@ -73,7 +73,7 @@ function annotationToJson(ann: Annotation): AnnotationJson {
         headers: [...ann.headers.entries()].sort(([a], [b]) => a.localeCompare(b)),
         method: ann.method,
         path: ann.path,
-        pathVariables: [...ann.pathVariables].sort((a, b) => a.localeCompare(b)),
+        pathVariables: ann.pathVariables,
         queryVariables: [...ann.queryVariables].sort((a, b) => a.localeCompare(b)),
       },
     };


### PR DESCRIPTION
Path variables were being sorted by name.

Fixes #712.