### PR TITLE
Add Interceptors on Dart Runtime

### DIFF
--- a/dart-runtime/lib/http_client.dart
+++ b/dart-runtime/lib/http_client.dart
@@ -22,6 +22,12 @@ class SdkgenErrorWithData<T> implements Exception {
   SdkgenErrorWithData(this.message, this.data);
 }
 
+class SdkgenInterceptors {
+  Future Function(Map<String, dynamic> body)? onRequest;
+  Future Function(dynamic error)? onError;
+  Future Function(dynamic response)? onResponse;
+}
+
 class SdkgenHttpClient {
   Uri baseUrl;
   Map<String, dynamic> extra = <String, dynamic>{};
@@ -33,6 +39,7 @@ class SdkgenHttpClient {
   Map<String, SdkgenErrorDescription> errTable;
   String? deviceId;
   Random random = Random.secure();
+  final SdkgenInterceptors interceptors = SdkgenInterceptors();
 
   SdkgenHttpClient(baseUrl, this.typeTable, this.fnTable, this.errTable)
       : baseUrl = Uri.parse(baseUrl);
@@ -41,11 +48,15 @@ class SdkgenHttpClient {
     return hex.encode(List<int>.generate(bytes, (i) => random.nextInt(256)));
   }
 
-  dynamic _throwError(String type, String message, dynamic data) {
+  dynamic _createError(String type, String message, dynamic data) {
     var description = errTable[type] ?? errTable['Fatal']!;
     var decodedData =
         decode(typeTable, '$type.data', description.dataType, data);
-    throw Function.apply(description.create, [message, decodedData]);
+    return Function.apply(description.create, [message, decodedData]);
+  }
+
+  dynamic _throwError(String type, String message, dynamic data) {
+    throw _createError(type, message, data);
   }
 
   Future<String> _deviceId() async {
@@ -62,7 +73,9 @@ class SdkgenHttpClient {
   }
 
   Future<Object?> makeRequest(
-      String functionName, Map<String, Object?> args) async {
+    String functionName,
+    Map<String, Object?> args,
+  ) async {
     try {
       var func = fnTable[functionName]!;
       var encodedArgs = {};
@@ -80,6 +93,8 @@ class SdkgenHttpClient {
         'deviceInfo': await getDeviceInfo(await _deviceId())
       };
 
+      await interceptors.onRequest?.call(body);
+
       var response = await http.post(
         baseUrl,
         headers: headers,
@@ -92,14 +107,22 @@ class SdkgenHttpClient {
         throw _throwError(responseBody['error']['type'],
             responseBody['error']['message'], responseBody['error']['data']);
       } else {
-        return decode(
+        final response = decode(
             typeTable, '$functionName.ret', func.ret, responseBody['result']);
+
+        await interceptors.onResponse?.call(response);
+
+        return response;
       }
     } catch (e) {
       if (e is SdkgenError || e is SdkgenErrorWithData) {
+        await interceptors.onError?.call(e);
         rethrow;
       } else {
-        throw _throwError('Fatal', e.toString(), null);
+        final error = _createError('Fatal', e.toString(), null);
+        await interceptors.onError?.call(error);
+
+        throw error;
       }
     }
   }

--- a/dart-runtime/lib/http_client.dart
+++ b/dart-runtime/lib/http_client.dart
@@ -55,10 +55,6 @@ class SdkgenHttpClient {
     return Function.apply(description.create, [message, decodedData]);
   }
 
-  dynamic _throwError(String type, String message, dynamic data) {
-    throw _createError(type, message, data);
-  }
-
   Future<String> _deviceId() async {
     if (deviceId == null) {
       var prefs = await SharedPreferences.getInstance();
@@ -104,7 +100,7 @@ class SdkgenHttpClient {
       var responseBody = jsonDecode(utf8.decode(response.bodyBytes));
 
       if (responseBody['error'] != null) {
-        throw _throwError(responseBody['error']['type'],
+        throw _createError(responseBody['error']['type'],
             responseBody['error']['message'], responseBody['error']['data']);
       } else {
         final response = decode(


### PR DESCRIPTION
This PR adds interceptors to `dart-runtime` project, inspired by the famous dio package. Basically calls an fn in three moments:
- Before sending a request (`onRequest`) 
- After receiving a response (`onResponse`) 
- After an error occurs (`onError`)

all the developer needs to do is assign one of these fns.