### PR TITLE
Adding possibility of okhttp interceptors to android

### DIFF
--- a/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
+++ b/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
@@ -126,22 +126,20 @@ open class SdkgenHttpClient(
     private val random = Random()
     private val hexArray = "0123456789abcdef".toCharArray()
     private val gson = Gson()
-
-    private val baseHttpClient = OkHttpClient.Builder()
+    private var httpClient = OkHttpClient.Builder()
         .connectTimeout(5, TimeUnit.MINUTES)
         .readTimeout(5, TimeUnit.MINUTES)
         .callTimeout(5, TimeUnit.MINUTES)
         .writeTimeout(5, TimeUnit.MINUTES)
-
-    private var httpClient = baseHttpClient.let {
-        if (httpInterceptor != null) {
-            it.addInterceptor(httpInterceptor)
+        .apply {
+            if (httpInterceptor != null) {
+                addInterceptor(httpInterceptor)
+            }
+            if (httpNetworkInterceptor != null) {
+                addNetworkInterceptor(httpNetworkInterceptor)
+            }
         }
-        if (httpNetworkInterceptor != null) {
-            it.addNetworkInterceptor(httpNetworkInterceptor)
-        }
-        it.build()
-    }
+        .build()
 
     private fun callId(): String {
         val bytes = ByteArray(8)

--- a/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
+++ b/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
@@ -31,7 +31,8 @@ open class SdkgenHttpClient(
     private val applicationContext: Context,
     private val defaultTimeoutMillis: Long = 10000L,
     private val fingerprint: String? = null,
-    private val httpInterceptor: Interceptor? = null
+    private val httpInterceptor: Interceptor? = null,
+    private val httpNetworkInterceptor: Interceptor? = null
 ) {
 
     val extras = mutableMapOf<String, Any>()
@@ -125,18 +126,21 @@ open class SdkgenHttpClient(
     private val random = Random()
     private val hexArray = "0123456789abcdef".toCharArray()
     private val gson = Gson()
-    private var httpClient = httpInterceptor.let {
-        val builder = OkHttpClient.Builder()
-            .connectTimeout(5, TimeUnit.MINUTES)
-            .readTimeout(5, TimeUnit.MINUTES)
-            .callTimeout(5, TimeUnit.MINUTES)
-            .writeTimeout(5, TimeUnit.MINUTES)
 
-        if (it != null) {
-            builder.addInterceptor(it).build()
-        } else {
-            builder.build()
+    private val baseHttpClient = OkHttpClient.Builder()
+        .connectTimeout(5, TimeUnit.MINUTES)
+        .readTimeout(5, TimeUnit.MINUTES)
+        .callTimeout(5, TimeUnit.MINUTES)
+        .writeTimeout(5, TimeUnit.MINUTES)
+
+    private var httpClient = baseHttpClient.let {
+        if (httpInterceptor != null) {
+            it.addInterceptor(httpInterceptor)
         }
+        if (httpNetworkInterceptor != null) {
+            it.addNetworkInterceptor(httpNetworkInterceptor)
+        }
+        it.build()
     }
 
     private fun callId(): String {

--- a/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
+++ b/android-runtime/runtime/src/main/java/io/sdkgen/runtime/SdkgenHttpClient.kt
@@ -21,6 +21,7 @@ import kotlin.coroutines.suspendCoroutine
 import android.util.Base64
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
+import okhttp3.Interceptor
 import okhttp3.Response
 import java.text.SimpleDateFormat
 
@@ -29,7 +30,8 @@ open class SdkgenHttpClient(
     private val baseUrl: String,
     private val applicationContext: Context,
     private val defaultTimeoutMillis: Long = 10000L,
-    private val fingerprint: String? = null
+    private val fingerprint: String? = null,
+    private val httpInterceptor: Interceptor? = null
 ) {
 
     val extras = mutableMapOf<String, Any>()
@@ -123,12 +125,19 @@ open class SdkgenHttpClient(
     private val random = Random()
     private val hexArray = "0123456789abcdef".toCharArray()
     private val gson = Gson()
-    private var httpClient = OkHttpClient.Builder()
-        .connectTimeout(5, TimeUnit.MINUTES)
-        .readTimeout(5, TimeUnit.MINUTES)
-        .callTimeout(5, TimeUnit.MINUTES)
-        .writeTimeout(5, TimeUnit.MINUTES)
-        .build()
+    private var httpClient = httpInterceptor.let {
+        val builder = OkHttpClient.Builder()
+            .connectTimeout(5, TimeUnit.MINUTES)
+            .readTimeout(5, TimeUnit.MINUTES)
+            .callTimeout(5, TimeUnit.MINUTES)
+            .writeTimeout(5, TimeUnit.MINUTES)
+
+        if (it != null) {
+            builder.addInterceptor(it).build()
+        } else {
+            builder.build()
+        }
+    }
 
     private fun callId(): String {
         val bytes = ByteArray(8)

--- a/kotlin-generator/src/android-client.ts
+++ b/kotlin-generator/src/android-client.ts
@@ -33,8 +33,9 @@ class ApiClient(
     val applicationContext: Context,
     defaultTimeoutMillis: Long = 10000L,
     fingerprint: String? = null,
-    httpInterceptor: Interceptor? = null
-) : SdkgenHttpClient(baseUrl, applicationContext, defaultTimeoutMillis, fingerprint, httpInterceptor) {
+    httpInterceptor: Interceptor? = null,
+    httpNetworkInterceptor: Interceptor? = null
+) : SdkgenHttpClient(baseUrl, applicationContext, defaultTimeoutMillis, fingerprint, httpInterceptor, httpNetworkInterceptor) {
 
     private val gson = GsonBuilder()
         .registerTypeAdapter(object : TypeToken<ByteArray>() {}.type, ByteArrayDeserializer())

--- a/kotlin-generator/src/android-client.ts
+++ b/kotlin-generator/src/android-client.ts
@@ -19,6 +19,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.parcelize.RawValue
 import java.util.*
+import okhttp3.Interceptor
 
 inline fun <reified T> Gson.fromJson(json: String) =
     fromJson<T>(json, object : TypeToken<T>() {}.type)
@@ -31,8 +32,9 @@ class ApiClient(
     baseUrl: String,
     val applicationContext: Context,
     defaultTimeoutMillis: Long = 10000L,
-    fingerprint: String? = null
-) : SdkgenHttpClient(baseUrl, applicationContext, defaultTimeoutMillis, fingerprint) {
+    fingerprint: String? = null,
+    httpInterceptor: Interceptor? = null
+) : SdkgenHttpClient(baseUrl, applicationContext, defaultTimeoutMillis, fingerprint, httpInterceptor) {
 
     private val gson = GsonBuilder()
         .registerTypeAdapter(object : TypeToken<ByteArray>() {}.type, ByteArrayDeserializer())


### PR DESCRIPTION
While creating a mock offline test version of an Android Application i noticed there wasn't a way to add interceptors to the httpClient.

- Added possible `Interceptor` to httpClient builder
- Added possible `networkInterceptor` to httpClient builder

This is 100% not needed to the normal utilization of sdkgen but only a possible option for mocked test scenarios