### PR TITLE
Fix: Javascript date encoding

### DIFF
--- a/browser-runtime/src/encode-decode.ts
+++ b/browser-runtime/src/encode-decode.ts
@@ -190,7 +190,12 @@ export function encode(typeTable: DeepReadonly<TypeTable>, path: string, type: D
       throw new ParseError(path, type, value);
     }
 
-    return typeof value === "string" ? new Date(value).toISOString().split("T")[0] : value.toISOString().split("T")[0];
+    const dateValue = value instanceof Date ? value : new Date(value);
+
+    return `${dateValue.getFullYear().toString().padStart(4, "0")}-${dateValue.getMonth().toString().padStart(2, "0")}-${dateValue
+      .getDate()
+      .toString()
+      .padStart(2, "0")}`;
   } else if (type === "datetime") {
     if (
       !(value instanceof Date && !isNaN(value.getTime())) &&

--- a/browser-runtime/tsconfig.json
+++ b/browser-runtime/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["ES2017"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/node-runtime/src/encode-decode.ts
+++ b/node-runtime/src/encode-decode.ts
@@ -300,7 +300,12 @@ export function encode<Table extends DeepReadonly<TypeTable>, Type extends DeepR
       throw new ParseError(path, type, value);
     }
 
-    return (typeof value === "string" ? new Date(value).toISOString().split("T")[0] : value.toISOString().split("T")[0]) as EncodedType<Type, Table>;
+    const dateValue = value instanceof Date ? value : new Date(value);
+
+    return `${dateValue.getFullYear().toString().padStart(4, "0")}-${dateValue.getMonth().toString().padStart(2, "0")}-${dateValue
+      .getDate()
+      .toString()
+      .padStart(2, "0")}` as EncodedType<Type, Table>;
   } else if (type === "datetime") {
     if (
       !(value instanceof Date && !isNaN(value.getTime())) &&


### PR DESCRIPTION
### Problem
Node and browser runtime are using the toIsoString method from the Date constructor to convert the date received into a string, before extracting the year, month, and date when encoding an argument of the type date. That can change the original date sent as an argument based on the timezone of the Date instance passed (see [this](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) for more info).

### Solution
Extract the year, month, and date directly from the original Date instance passed.