### PR TITLE
Fix: remove unnecessary dart import

### DIFF
--- a/dart-generator/src/dart-client.ts
+++ b/dart-generator/src/dart-client.ts
@@ -7,7 +7,6 @@ export function generateDartClientSource(ast: AstRoot): string {
   let code = "";
 
   code += `// ignore_for_file: constant_identifier_names
-import 'dart:ui';
 `;
 
   if (hasType(ast, BytesPrimitiveType)) {


### PR DESCRIPTION
As `hashList` function is not used anymore #741 therefore `dart:ui` import is not need 