### PR TITLE
feat: show swagger authorize button and better use of tags

### DIFF
--- a/node-runtime/src/swagger.ts
+++ b/node-runtime/src/swagger.ts
@@ -227,10 +227,6 @@ function getSwaggerJson<ExtraContextT>(apiConfig: BaseApiConfig<ExtraContextT>) 
       ]),
     );
 
-    const tags = Array.from(
-      new Set(op.annotations.filter((ann): ann is RestAnnotation => ann instanceof RestAnnotation).map(ann => ann.path.split("/")[1])),
-    );
-
     for (const ann of op.annotations) {
       if (ann instanceof RestAnnotation) {
         if (!paths[ann.path]) {
@@ -354,7 +350,7 @@ function getSwaggerJson<ExtraContextT>(apiConfig: BaseApiConfig<ExtraContextT>) 
               .filter(x => x instanceof DescriptionAnnotation)
               .map(x => (x as DescriptionAnnotation).text)
               .join(" ") || undefined,
-          tags: [tags.find(tag => ann.path.startsWith(`/${tag}`))],
+          tags: [ann.path.split("/")[1]],
         };
       }
     }

--- a/node-runtime/src/swagger.ts
+++ b/node-runtime/src/swagger.ts
@@ -227,6 +227,10 @@ function getSwaggerJson<ExtraContextT>(apiConfig: BaseApiConfig<ExtraContextT>) 
       ]),
     );
 
+    const tags = Array.from(
+      new Set(op.annotations.filter((ann): ann is RestAnnotation => ann instanceof RestAnnotation).map(ann => ann.path.split("/")[1])),
+    );
+
     for (const ann of op.annotations) {
       if (ann instanceof RestAnnotation) {
         if (!paths[ann.path]) {
@@ -350,7 +354,7 @@ function getSwaggerJson<ExtraContextT>(apiConfig: BaseApiConfig<ExtraContextT>) 
               .filter(x => x instanceof DescriptionAnnotation)
               .map(x => (x as DescriptionAnnotation).text)
               .join(" ") || undefined,
-          tags: ["REST Endpoints"],
+          tags: [tags.find(tag => ann.path.startsWith(`/${tag}`))],
         };
       }
     }
@@ -418,7 +422,7 @@ export function setupSwagger<ExtraContextT>(server: SdkgenHttpServer<ExtraContex
                         background: #fafafa;
                     }
 
-                    .swagger-ui .scheme-container, .swagger-ui .topbar {
+                    .topbar {
                         display: none !important;
                     }
                 </style>


### PR DESCRIPTION
Changes:
- The Swagger `authorize` button is not hidden anymore
- Endpoints are separated by tags created by the first name of the path.

![image](https://user-images.githubusercontent.com/31698109/232117726-a1d65a62-41f5-4bd3-b055-ca312ee4d010.png)
