### PR TITLE
feat(playground): add extras tab to simple-call-component

### DIFF
--- a/playground/src/app/simple-call/simple-call.component.html
+++ b/playground/src/app/simple-call/simple-call.component.html
@@ -11,20 +11,17 @@
             <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="code"></ngx-monaco-editor>
           </mat-tab>
 
+          <mat-tab label="Extras">
+            <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="extras"></ngx-monaco-editor>
+          </mat-tab>
+
           <mat-tab label="Resposta" [disabled]="!response">
             <ngx-json-viewer [json]="response"></ngx-json-viewer>
           </mat-tab>
         </mat-tab-group>
       </as-split-area>
-      <as-split-area>
-        <mat-tab-group animationDuration="0ms" [selectedIndex]="selected.value"
-          (selectedIndexChange)="selected.setValue($event)">
-          <mat-tab label="Extras">
-            <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="extras"></ngx-monaco-editor>
-          </mat-tab>
-        </mat-tab-group>
 
-      </as-split-area>
+
     </as-split>
   </as-split-area>
 

--- a/playground/src/app/simple-call/simple-call.component.html
+++ b/playground/src/app/simple-call/simple-call.component.html
@@ -6,6 +6,7 @@
         <button mat-fab class="run-fab" (click)="run()">
           <mat-icon>play_arrow</mat-icon>
         </button>
+
         <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="code"></ngx-monaco-editor>
       </mat-tab>
 

--- a/playground/src/app/simple-call/simple-call.component.html
+++ b/playground/src/app/simple-call/simple-call.component.html
@@ -1,27 +1,23 @@
 <as-split direction="vertical">
   <as-split-area>
     <as-split>
-      <as-split-area>
-        <mat-tab-group animationDuration="0ms" [selectedIndex]="selected.value"
-          (selectedIndexChange)="selected.setValue($event)">
-          <mat-tab label="Requisição">
-            <button mat-fab class="run-fab" (click)="run()">
-              <mat-icon>play_arrow</mat-icon>
-            </button>
-            <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="code"></ngx-monaco-editor>
-          </mat-tab>
+      <mat-tab-group animationDuration="0ms" [selectedIndex]="selected.value"
+        (selectedIndexChange)="selected.setValue($event)">
+        <mat-tab label="Requisição">
+          <button mat-fab class="run-fab" (click)="run()">
+            <mat-icon>play_arrow</mat-icon>
+          </button>
+          <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="code"></ngx-monaco-editor>
+        </mat-tab>
 
-          <mat-tab label="Extras">
-            <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="extras"></ngx-monaco-editor>
-          </mat-tab>
+        <mat-tab label="Extras">
+          <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="extras"></ngx-monaco-editor>
+        </mat-tab>
 
-          <mat-tab label="Resposta" [disabled]="!response">
-            <ngx-json-viewer [json]="response"></ngx-json-viewer>
-          </mat-tab>
-        </mat-tab-group>
-      </as-split-area>
-
-
+        <mat-tab label="Resposta" [disabled]="!response">
+          <ngx-json-viewer [json]="response"></ngx-json-viewer>
+        </mat-tab>
+      </mat-tab-group>
     </as-split>
   </as-split-area>
 

--- a/playground/src/app/simple-call/simple-call.component.html
+++ b/playground/src/app/simple-call/simple-call.component.html
@@ -1,18 +1,31 @@
 <as-split direction="vertical">
   <as-split-area>
-    <mat-tab-group animationDuration="0ms" [selectedIndex]="selected.value" (selectedIndexChange)="selected.setValue($event)">
-      <mat-tab label="Requisição">
-        <button mat-fab class="run-fab" (click)="run()">
-          <mat-icon>play_arrow</mat-icon>
-        </button>
+    <as-split>
+      <as-split-area>
+        <mat-tab-group animationDuration="0ms" [selectedIndex]="selected.value"
+          (selectedIndexChange)="selected.setValue($event)">
+          <mat-tab label="Requisição">
+            <button mat-fab class="run-fab" (click)="run()">
+              <mat-icon>play_arrow</mat-icon>
+            </button>
+            <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="code"></ngx-monaco-editor>
+          </mat-tab>
 
-        <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="code"></ngx-monaco-editor>
-      </mat-tab>
+          <mat-tab label="Resposta" [disabled]="!response">
+            <ngx-json-viewer [json]="response"></ngx-json-viewer>
+          </mat-tab>
+        </mat-tab-group>
+      </as-split-area>
+      <as-split-area>
+        <mat-tab-group animationDuration="0ms" [selectedIndex]="selected.value"
+          (selectedIndexChange)="selected.setValue($event)">
+          <mat-tab label="Extras">
+            <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="extras"></ngx-monaco-editor>
+          </mat-tab>
+        </mat-tab-group>
 
-      <mat-tab label="Resposta" [disabled]="!response">
-        <ngx-json-viewer [json]="response"></ngx-json-viewer>
-      </mat-tab>
-    </mat-tab-group>
+      </as-split-area>
+    </as-split>
   </as-split-area>
 
   <as-split-area [size]="30">

--- a/playground/src/app/simple-call/simple-call.component.html
+++ b/playground/src/app/simple-call/simple-call.component.html
@@ -1,24 +1,22 @@
 <as-split direction="vertical">
   <as-split-area>
-    <as-split>
-      <mat-tab-group animationDuration="0ms" [selectedIndex]="selected.value"
-        (selectedIndexChange)="selected.setValue($event)">
-        <mat-tab label="Requisição">
-          <button mat-fab class="run-fab" (click)="run()">
-            <mat-icon>play_arrow</mat-icon>
-          </button>
-          <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="code"></ngx-monaco-editor>
-        </mat-tab>
+    <mat-tab-group animationDuration="0ms" [selectedIndex]="selected.value"
+      (selectedIndexChange)="selected.setValue($event)">
+      <mat-tab label="Requisição">
+        <button mat-fab class="run-fab" (click)="run()">
+          <mat-icon>play_arrow</mat-icon>
+        </button>
+        <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="code"></ngx-monaco-editor>
+      </mat-tab>
 
-        <mat-tab label="Extras">
-          <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="extras"></ngx-monaco-editor>
-        </mat-tab>
+      <mat-tab label="Extras">
+        <ngx-monaco-editor [options]="editorOptions" [(ngModel)]="extras"></ngx-monaco-editor>
+      </mat-tab>
 
-        <mat-tab label="Resposta" [disabled]="!response">
-          <ngx-json-viewer [json]="response"></ngx-json-viewer>
-        </mat-tab>
-      </mat-tab-group>
-    </as-split>
+      <mat-tab label="Resposta" [disabled]="!response">
+        <ngx-json-viewer [json]="response"></ngx-json-viewer>
+      </mat-tab>
+    </mat-tab-group>
   </as-split-area>
 
   <as-split-area [size]="30">

--- a/playground/src/app/simple-call/simple-call.component.ts
+++ b/playground/src/app/simple-call/simple-call.component.ts
@@ -26,7 +26,9 @@ export class SimpleCallComponent implements OnInit, OnDestroy {
 
   client?: SdkgenHttpClient;
   code = "";
-  extras = "{}";
+  extras = `{
+  "key": "value"
+}`;
   response?: any;
 
   selected = new FormControl(0);
@@ -57,20 +59,26 @@ export class SimpleCallComponent implements OnInit, OnDestroy {
       eval(wrapper);
     }
 
-    if (this.extras !== "{}" && this.extras !== "") {
-      const extrasJson = JSON.parse(this.extras);
-      const extraKeys = Object.keys(extrasJson);
-
-      for (const key of extraKeys) {
-        this.client?.extra.set(key, extrasJson[key]);
-      }
-    }
-
     const exec = (this.client as unknown as Record<string, (data: any) => Promise<any>>)[this.fn](
       JSON.parse(this.code),
     );
 
     try {
+      if (
+        this.extras !==
+          `{
+        "key": "value"
+      }` &&
+        this.extras
+      ) {
+        const extrasJson = JSON.parse(this.extras);
+        const extraKeys = Object.keys(extrasJson);
+
+        for (const key of extraKeys) {
+          this.client?.extra.set(key, extrasJson[key]);
+        }
+      }
+
       this.response = { result: await exec };
     } catch (e: any) {
       this.consoleItems.push({ type: ConsoleItemType.ERROR, message: e.toString() });

--- a/playground/src/app/simple-call/simple-call.component.ts
+++ b/playground/src/app/simple-call/simple-call.component.ts
@@ -63,13 +63,7 @@ export class SimpleCallComponent implements OnInit, OnDestroy {
     );
 
     try {
-      if (
-        this.extras !==
-          `{
-        "key": "value"
-      }` &&
-        this.extras
-      ) {
+      if (this.extras && this.extras !== this.initialExtras) {
         const extrasJson = JSON.parse(this.extras);
         const extraKeys = Object.keys(extrasJson);
 

--- a/playground/src/app/simple-call/simple-call.component.ts
+++ b/playground/src/app/simple-call/simple-call.component.ts
@@ -26,9 +26,8 @@ export class SimpleCallComponent implements OnInit, OnDestroy {
 
   client?: SdkgenHttpClient;
   code = "";
-  extras = `{
-  "key": "value"
-}`;
+  initialExtras = `{\n  "key": "value"\n}\n`;
+  extras = this.initialExtras;
   response?: any;
 
   selected = new FormControl(0);

--- a/playground/src/app/simple-call/simple-call.component.ts
+++ b/playground/src/app/simple-call/simple-call.component.ts
@@ -26,6 +26,7 @@ export class SimpleCallComponent implements OnInit, OnDestroy {
 
   client?: SdkgenHttpClient;
   code = "";
+  extras = "{}";
   response?: any;
 
   selected = new FormControl(0);
@@ -54,6 +55,15 @@ export class SimpleCallComponent implements OnInit, OnDestroy {
       const events = this.consoleItems;
 
       eval(wrapper);
+    }
+
+    if (this.extras !== "{}" && this.extras !== "") {
+      const extrasJson = JSON.parse(this.extras);
+      const extraKeys = Object.keys(extrasJson);
+
+      for (const key of extraKeys) {
+        this.client?.extra.set(key, extrasJson[key]);
+      }
     }
 
     const exec = (this.client as unknown as Record<string, (data: any) => Promise<any>>)[this.fn](

--- a/playground/src/app/tab-nav/tab-nav.component.ts
+++ b/playground/src/app/tab-nav/tab-nav.component.ts
@@ -48,7 +48,7 @@ export class TabNavComponent implements OnInit {
 
       console.debug("astUrl", astUrl);
 
-      const result = await fetch(astUrl).then(resp => (resp.ok ? resp.json() : resp));
+      const result = await fetch(astUrl).then(async resp => (resp.ok ? resp.json() : resp));
 
       if (result instanceof Response) {
         if (result instanceof Error) {


### PR DESCRIPTION
This PR adds a new tab in the simple call page to add the extras to the request page to send extras along with the request without the need to use advanced editor

![image](https://user-images.githubusercontent.com/24869058/233202004-4524943b-b8ce-49a4-ba44-338bd165f327.png)
