### PR TITLE
Possibilitar a desabilitação dos logs defaults

### DIFF
--- a/packages/node-runtime/.vscode/settings.json
+++ b/packages/node-runtime/.vscode/settings.json
@@ -3,7 +3,7 @@
   "editor.tabSize": 4,
   "files.insertFinalNewline": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": "explicit"
   },
   "eslint.validate": [
     "javascript",

--- a/packages/node-runtime/.vscode/settings.json
+++ b/packages/node-runtime/.vscode/settings.json
@@ -3,7 +3,7 @@
   "editor.tabSize": 4,
   "files.insertFinalNewline": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": "explicit"
+    "source.organizeImports": true
   },
   "eslint.validate": [
     "javascript",

--- a/packages/node-runtime/src/http-server.ts
+++ b/packages/node-runtime/src/http-server.ts
@@ -70,7 +70,13 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
 
   public introspection = true;
 
+  private enableLogs = true;
+
   public log = (message: string) => {
+    if (!this.enableLogs) {
+      return;
+    }
+
     console.log(`${new Date().toISOString()} ${message}`);
   };
 

--- a/packages/node-runtime/src/http-server.ts
+++ b/packages/node-runtime/src/http-server.ts
@@ -70,7 +70,7 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
 
   public introspection = true;
 
-  private enableLogs = true;
+  public enableLogs = true;
 
   public log = (message: string) => {
     if (!this.enableLogs) {


### PR DESCRIPTION
Hoje o SdkgenHttpServer está gerando logs automáticos a cada request recebida nos endpoints, com isso estamos incluindo um flag para possibilitar desabilitar esse log automático.