### PR TITLE
feat: implement interceptor pattern for SdkgenHttpClient

### DIFF
--- a/packages/dart-runtime/lib/interceptors.dart
+++ b/packages/dart-runtime/lib/interceptors.dart
@@ -1,0 +1,29 @@
+typedef OnRequestInterceptor = Future Function(Map<String, dynamic> body);
+typedef OnResponseInterceptor = Future Function(dynamic response);
+typedef OnErrorInterceptor = Future Function(dynamic error);
+
+abstract class SdkgenInterceptors {
+  OnRequestInterceptor? get onRequest;
+  OnResponseInterceptor? get onResponse;
+  OnErrorInterceptor? get onError;
+}
+
+extension SdkgenInterceptorsExtension on List<SdkgenInterceptors> {
+  Future onRequest(Map<String, dynamic> body) async {
+    for (final interceptors in this) {
+      await interceptors.onRequest?.call(body);
+    }
+  }
+
+  Future onResponse(dynamic response) async {
+    for (final interceptors in this) {
+      await interceptors.onResponse?.call(response);
+    }
+  }
+
+  Future onError(dynamic error) async {
+    for (final interceptors in this) {
+      await interceptors.onError?.call(error);
+    }
+  }
+}

--- a/packages/dart-runtime/test/interceptors_test.dart
+++ b/packages/dart-runtime/test/interceptors_test.dart
@@ -1,0 +1,59 @@
+import 'package:sdkgen_runtime/interceptors.dart';
+import 'package:test/test.dart';
+
+class LogInterceptors implements SdkgenInterceptors {
+  final List<String> logs = [];
+
+  @override
+  OnErrorInterceptor? get onError {
+    return (error) async {
+      logs.add('on_error_called');
+      return print(error.toString());
+    };
+  }
+
+  @override
+  OnRequestInterceptor? get onRequest {
+    return (body) async {
+      logs.add('on_request_called');
+      return print(body.toString());
+    };
+  }
+
+  @override
+  OnResponseInterceptor? get onResponse {
+    return (response) async {
+      logs.add('on_response_called');
+      return print(response.toString());
+    };
+  }
+}
+
+void main() {
+  test('onRequest interceptor is called', () async {
+    final logInterceptors = LogInterceptors();
+    final interceptors = [logInterceptors];
+
+    await interceptors.onRequest({'key': 'value'});
+
+    expect(logInterceptors.logs, contains('on_request_called'));
+  });
+
+  test('onResponse interceptor is called', () async {
+    final logInterceptors = LogInterceptors();
+    final interceptors = [logInterceptors];
+
+    await interceptors.onResponse({'response': 'data'});
+
+    expect(logInterceptors.logs, contains('on_response_called'));
+  });
+
+  test('onError interceptor is called', () async {
+    final logInterceptors = LogInterceptors();
+    final interceptors = [logInterceptors];
+
+    await interceptors.onError(Exception('Test error'));
+
+    expect(logInterceptors.logs, contains('on_error_called'));
+  });
+}


### PR DESCRIPTION
This PR introduces an improvement to the use of sdkgen interceptors. The new approach allows multiple interceptors to be used in a chained fashion, improving flexibility and code organization. Additionally, an extension for interceptor lists has been added, making it easier to execute all interceptors registered for onRequest, onResponse, and onError events.

Motivation for Changes:
Previously, the SDK only allowed a single interceptor per event (`onRequest`, `onResponse`, `onError`). This limitation made it difficult to implement distinct functionalities, such as authentication, logging, and validation, at the same time.

Organization and Reuse:
Separating responsibilities into different classes (such as LogInterceptors and AuthInterceptors) improves code readability and maintainability.

Ease of Use:
With the added extension, it is possible to execute all interceptors sequentially without the need for manual logic on the client.

It is now possible to add and use multiple interceptors on the client as follows:

```dart
class LogInterceptors implements SdkgenInterceptors {
  @override
  OnErrorInterceptor? get onError =>  (error) async=> print(error.toString());

  @override
  OnRequestInterceptor? get onRequest => (body) async => print(body.toString());

  @override
  OnResponseInterceptor? get onResponse => (response) async=> print(response.toString());
}

class AuthInterceptors implements SdkgenInterceptors {
  ...
}

apiClient.addInterceptor(LogInterceptors());
apiClient.addInterceptor(AuthInterceptors());

```

- [ ] Node server
- [ ] F# server
- [ ] Node client
- [ ] Browser client
- [x] Flutter client
- [ ] Android client
- [ ] iOS client
- [ ] Playground