### PR TITLE
[FIX] Fix error when trying to set type property of Error class

### DIFF
--- a/packages/browser-runtime/src/error.ts
+++ b/packages/browser-runtime/src/error.ts
@@ -1,6 +1,10 @@
 export abstract class SdkgenError extends Error {
-  get type(): string {
-    return this.constructor.name;
+  type: string;
+
+  constructor(message: string, type: string) {
+    super(message);
+    this.message = message;
+    this.type = type;
   }
 
   public toJSON(): { message: string; type: string } {
@@ -13,9 +17,10 @@ export abstract class SdkgenError extends Error {
 export abstract class SdkgenErrorWithData<DataType> extends SdkgenError {
   constructor(
     message: string,
+    type: string,
     public data: DataType,
   ) {
-    super(message);
+    super(message, type);
   }
 
   public toJSON(): { data: DataType; message: string; type: string } {


### PR DESCRIPTION
This MR fixes a runtime error that occurred when attempting to assign a value to the type property of an Error instance:

Cannot set property type of Error which has only a getter

The issue was caused by trying to overwrite a property that either does not exist on the native Error class or is defined as read-only in one of the custom error classes.
To resolve this, the custom error class has been updated to define type as a writable property, allowing it to be assigned dynamically during instantiation.

![image](https://github.com/user-attachments/assets/544a4385-8d6f-4149-abbb-53a0412bb953)
