### PR TITLE
fix(node-runtime): ensure Async Context is propagated to request handlers

### DIFF
--- a/packages/node-runtime/src/http-server.ts
+++ b/packages/node-runtime/src/http-server.ts
@@ -678,23 +678,23 @@ export class SdkgenHttpServer<ExtraContextT = unknown> {
       return;
     }
 
-    const handleBody = (body: Buffer) => {
-      this.handleRequestWithBody(req, res, body, hrStart).catch((e: unknown) => this.writeReply(res, null, { error: e }, hrStart));
-    };
+    new Promise<Buffer>(resolve => {
+      // Google Cloud Functions add a rawBody property to the request object
+      if (has(req, "rawBody") && req.rawBody instanceof Buffer) {
+        resolve(req.rawBody);
+      } else {
+        const body: Uint8Array[] = [];
 
-    // Google Cloud Functions add a rawBody property to the request object
-    if (has(req, "rawBody") && req.rawBody instanceof Buffer) {
-      handleBody(req.rawBody);
-    } else {
-      const body: Buffer[] = [];
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        req.on("data", chunk => body.push(chunk));
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      req.on("data", chunk => body.push(chunk));
-
-      req.on("end", () => {
-        handleBody(Buffer.concat(body));
-      });
-    }
+        req.on("end", () => {
+          resolve(Buffer.concat(body));
+        });
+      }
+    })
+      .then(async body => this.handleRequestWithBody(req, res, body, hrStart))
+      .catch((e: unknown) => this.writeReply(res, null, { error: e }, hrStart));
   };
 
   private async handleRequestWithBody(req: IncomingMessage, res: ServerResponse, body: Buffer, hrStart: [number, number]) {


### PR DESCRIPTION
This PR fixes a problem with [dd-trace](https://github.com/Datadog/dd-trace-js) where during an HTTP request the Async Context was lost and `ddtrace.scope().active()` returned null.

Test project: [test-dd.zip](https://github.com/user-attachments/files/27255393/test-dd.zip)

| Call stack and behavior before this fix | Call stack (now includes dd-trace stacks) and behavior after this fix |
|--------|--------|
| <img width="1290" height="824" alt="SCR-20260430-ncyc" src="https://github.com/user-attachments/assets/f7b61b43-c356-4522-b1e3-2ec84706d8f1" /> | <img width="1180" height="909" alt="SCR-20260430-nern" src="https://github.com/user-attachments/assets/f71f6b03-1281-44ad-9049-27650c2affa9" /> | 
