### PR TITLE
Fix browser bytes encoding for large ArrayBuffers

### DIFF
--- a/packages/browser-runtime/spec/encode-decode.spec.ts
+++ b/packages/browser-runtime/spec/encode-decode.spec.ts
@@ -1,0 +1,43 @@
+import { encode } from "../src/encode-decode";
+
+type Uint8ArrayWithBase64 = Uint8Array & {
+  toBase64?(): string;
+};
+
+describe("Encode/Decode", () => {
+  test("encodes small bytes ArrayBuffer as base64", () => {
+    const bytes = new Uint8Array([65, 66, 67, 255, 0]);
+
+    const encoded = encode({}, "test", "bytes", bytes.buffer);
+
+    expect(encoded).toBe("QUJD/wA=");
+    expect(atob(encoded as string).length).toBe(5);
+  });
+
+  test("encodes bytes ArrayBuffer larger than the function argument limit", () => {
+    const buffer = new ArrayBuffer(100000);
+
+    new Uint8Array(buffer).fill(65);
+
+    const encoded = encode({}, "test", "bytes", buffer);
+
+    expect(typeof encoded).toBe("string");
+    expect(atob(encoded as string).length).toBe(100000);
+    expect(encoded).toBe(Buffer.from(new Uint8Array(buffer)).toString("base64"));
+  });
+
+  test("encodes bytes Uint8Array as base64", () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+
+    expect(encode({}, "test", "bytes", bytes)).toBe("SGVsbG8=");
+  });
+
+  test("uses native Uint8Array base64 encoding when available", () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]) as Uint8ArrayWithBase64;
+
+    bytes.toBase64 = jest.fn(() => "SGVsbG8=");
+
+    expect(encode({}, "test", "bytes", bytes)).toBe("SGVsbG8=");
+    expect(bytes.toBase64).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/browser-runtime/src/encode-decode.ts
+++ b/packages/browser-runtime/src/encode-decode.ts
@@ -5,6 +5,11 @@ import type { DeepReadonly } from "./utils";
 
 const simpleStringTypes = ["string", "email", "phone", "html", "xml"];
 const simpleTypes = ["json", "bool", "url", "int", "uint", "float", "money", "hex", "uuid", "base64", "void", ...simpleStringTypes];
+const bytesEncodeChunkSize = 0x8000;
+
+type Uint8ArrayWithBase64 = Uint8Array & {
+  toBase64?(): string;
+};
 
 class ParseError extends Error {
   constructor(path: string, type: DeepReadonly<TypeDescription>, value: unknown) {
@@ -112,6 +117,28 @@ function simpleEncodeDecode(path: string, type: string, value: unknown) {
   throw new Error(`Unknown type '${type}' at '${path}'`);
 }
 
+function isBuffer(value: unknown): value is Buffer {
+  return typeof Buffer !== "undefined" && value instanceof Buffer;
+}
+
+function encodeBytes(value: ArrayBuffer | Uint8Array): string {
+  const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
+  const base64Bytes = bytes as Uint8ArrayWithBase64;
+  const { toBase64 } = base64Bytes;
+
+  if (typeof toBase64 === "function") {
+    return toBase64.call(bytes);
+  }
+
+  const chunks: string[] = [];
+
+  for (let index = 0; index < bytes.length; index += bytesEncodeChunkSize) {
+    chunks.push(String.fromCharCode(...Array.from(bytes.subarray(index, index + bytesEncodeChunkSize))));
+  }
+
+  return btoa(chunks.join(""));
+}
+
 export function encode(typeTable: DeepReadonly<TypeTable>, path: string, type: DeepReadonly<TypeDescription>, value: unknown): unknown {
   if (typeof type === "string" && !type.endsWith("?") && type !== "void" && (value === null || value === undefined)) {
     throw new Error(`Invalid type at '${path}', cannot be null`);
@@ -162,18 +189,15 @@ export function encode(typeTable: DeepReadonly<TypeTable>, path: string, type: D
   } else if (simpleTypes.indexOf(type) >= 0) {
     return simpleEncodeDecode(path, type, value);
   } else if (type === "bytes") {
-    if (!(value instanceof ArrayBuffer) && !(value instanceof Uint8Array) && !(value instanceof Buffer)) {
+    if (!(value instanceof ArrayBuffer) && !(value instanceof Uint8Array) && !isBuffer(value)) {
       throw new ParseError(path, type, value);
     }
 
-    if (value instanceof Buffer) {
+    if (isBuffer(value)) {
       return value.toString("base64");
     }
 
-    const uint8Array = new Uint8Array(value) as unknown as number[];
-    const charArray = uint8Array.map(byte => String.fromCharCode(byte));
-
-    return btoa(charArray.join(""));
+    return encodeBytes(value);
   } else if (type === "bigint") {
     if (!(typeof value === "bigint")) {
       throw new ParseError(path, type, value);


### PR DESCRIPTION
## Issue

Uploads using `bytes` fields can crash in apps using `@sdkgen/browser-runtime@2.3.2` with:

```txt
RangeError: Maximum call stack size exceeded
```

The regression is in the browser runtime `encode()` handler for `bytes`.

Published `2.3.2` encodes `ArrayBuffer` values with:

```js
btoa(String.fromCharCode.apply(String, new Uint8Array(value)))
```

That passes every byte as a function argument. JavaScript engines cap the number of arguments a single call can receive, so larger files can overflow the call stack. The exact threshold varies by engine/version.

This explains why the older `1.6.2` line appeared to work: it used `Buffer.toString("base64")`, which performs the conversion natively and does not push every byte through the JS call stack.

## Fix

- Keep the public wire format unchanged: `bytes` still encodes to base64 strings.
- Preserve support for `Buffer` when available.
- Support `ArrayBuffer` and `Uint8Array`.
- Use `Uint8Array.prototype.toBase64()` when the browser provides it.
- Fall back to chunked `String.fromCharCode(...)` with 32KB chunks when native `toBase64()` is unavailable.

The native path follows the Mozilla recommendation for converting `Uint8Array` data to base64:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/toBase64

## Compatibility

This should be safe as a patch release:

- no AST change;
- no request/response protocol change;
- no backend change required;
- output remains the same base64 payload;
- existing `Buffer` behavior is preserved;
- current browser `ArrayBuffer` behavior is preserved, but without the call stack overflow.

## Evidence

SDK package checks:

```sh
npm test --workspace @sdkgen/browser-runtime -- --runInBand
npm run build --workspace @sdkgen/browser-runtime
npm run eslint:check --workspace @sdkgen/browser-runtime
```

Results:

- unit tests passed: `4 passed`;
- build passed;
- lint passed with `0 errors` and `5` pre-existing `no-unsafe-argument` warnings.

Browser smoke via Playwright/Chromium:

```txt
User agent:
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.7632.6 Safari/537.36

Uint8Array.prototype.toBase64 available: true
```

Published `@sdkgen/browser-runtime@2.3.2`:

```json
[
  {
    "size": 100000,
    "ok": true,
    "decodedLength": 100000,
    "base64Length": 133336
  },
  {
    "size": 131072,
    "ok": false,
    "name": "RangeError",
    "message": "Maximum call stack size exceeded"
  }
]
```

Patched local runtime:

```json
[
  {
    "size": 131072,
    "ok": true,
    "decodedLength": 131072,
    "base64Length": 174764
  },
  {
    "size": 1048576,
    "ok": true,
    "decodedLength": 1048576,
    "base64Length": 1398104
  }
]
```

Consumer smoke local tests:

- temporarily installed the local tarball ;
- confirmed `node_modules/@sdkgen/browser-runtime` contained `toBase64()` and chunked fallback;
- smoke with `1MiB` returned `decodedLength: 1048576`;
- reverted the consumer back to `@sdkgen/browser-runtime@2.3.2` after testing.
