### PR TITLE
fix(typescript-generator): move Context import to type-only import and remove unused Fatal import

### DIFF
--- a/packages/typescript-generator/src/node-server.ts
+++ b/packages/typescript-generator/src/node-server.ts
@@ -10,7 +10,7 @@ export function generateNodeServerSource(ast: AstRoot): string {
   const hasErrorWithoutData = ast.errors.filter(err => err.name !== "Fatal").some(err => err.dataType instanceof VoidPrimitiveType);
 
   code += `/* eslint-disable */
-import { BaseApiConfig, Context, Fatal${hasErrorWithoutData ? ", SdkgenError" : ""}${
+import { BaseApiConfig, type Context${hasErrorWithoutData ? ", SdkgenError" : ""}${
     hasErrorWithData ? ", SdkgenErrorWithData" : ""
   } } from "@sdkgen/node-runtime";
 export { Fatal } from "@sdkgen/node-runtime";


### PR DESCRIPTION
With `verbatimModuleSyntax` enabled in tsconfig, sdkgen produces an invalid file with the following error:

```
'Context' is a type and must be imported using a type-only import when verbatimModuleSyntax' is enabled. ts(1484)
```

The Fatal import was also unused, as the export was exporting directly from `@sdkgen/node-runtime`.