### PR TITLE
feat: implement @tag annotation for function grouping in playground

### DIFF
--- a/docs/aprofundando/annotations.md
+++ b/docs/aprofundando/annotations.md
@@ -62,6 +62,25 @@ fn getUser(id: uuid)
 
 Neste exemplo a função `getUser` pode lançar o erro `NotFound` ou o erro `Forbidden`. Note que além desses dois, todas as funções podem lançar o erro `Fatal`, quando o comportamento sai do esperado. Erros do tipo `Fatal` devem sempre ser considerados como bugs do backend. Caso a função tente lançar algum dos erros não mapeados, este será convertido em `Fatal` para o cliente.
 
+## `@tag`
+
+A anotação `@tag` pode aparecer antes de funções e serve para agrupá-las em categorias. Ela é puramente informativa: não altera o comportamento da função, mas é utilizada pelo playground para organizar as funções em seções e também aparece como `tags` no Swagger/OpenAPI gerado. O valor é um texto livre, usado diretamente como o nome da categoria.
+
+Assim como o `@throws`, a anotação pode ser incluída múltiplas vezes para que uma mesma função apareça em mais de uma categoria. Funções sem `@tag` são agrupadas em uma categoria padrão ("(Sem tags)") no playground.
+
+```
+@tag Usuários
+@tag Administração
+@description Promove um usuário a administrador.
+fn promoteToAdmin(id: uuid)
+
+@tag Usuários
+@description Obtém o usuário atual.
+fn getUser(): User?
+```
+
+Neste exemplo a função `promoteToAdmin` aparecerá tanto na categoria "Usuários" quanto na "Administração", enquanto `getUser` aparecerá apenas em "Usuários".
+
 ## `@hidden`
 
 Por padrão todas as funções podem ser chamadas no playground e são parte dos targets de clientes gerados. Caso uma função precise existir, mas não deva ser chamada normalmente, a anotação `@hidden` pode ser aplicada. As funções ocultas não existirão no playground ou nos target gerados, sendo útil para depreciar funções antigas ou para marcar funções para serem utilizadas exclusivamente como [REST](./rest.md). Repare que funções marcadas como `@hidden` ainda existem e ainda podem ser chamadas, especialmente por targets antigos. Não use para efeitos de segurança. Exemplo:

--- a/packages/node-runtime/src/swagger.ts
+++ b/packages/node-runtime/src/swagger.ts
@@ -1,6 +1,7 @@
 import type { ErrorNode, Type } from "@sdkgen/parser";
 import {
   StatusCodeAnnotation,
+  TagAnnotation,
   ThrowsAnnotation,
   DecimalPrimitiveType,
   JsonPrimitiveType,
@@ -172,6 +173,7 @@ function getSwaggerJson<ExtraContextT>(apiConfig: BaseApiConfig<ExtraContextT>) 
   const paths: Record<string, any> = {};
 
   for (const op of apiConfig.ast.operations) {
+    const tagAnnotations = op.annotations.filter(ann => ann instanceof TagAnnotation) as TagAnnotation[];
     const throwAnnotations = op.annotations.filter(ann => ann instanceof ThrowsAnnotation) as ThrowsAnnotation[];
     let possibleErrors = throwAnnotations.map(ann => apiConfig.ast.errors.find(err => err.name === ann.error)).filter(x => x) as ErrorNode[];
 
@@ -351,7 +353,7 @@ function getSwaggerJson<ExtraContextT>(apiConfig: BaseApiConfig<ExtraContextT>) 
               .filter(x => x instanceof DescriptionAnnotation)
               .map(x => (x as DescriptionAnnotation).text)
               .join(" ") || undefined,
-          tags: [ann.path.split("/")[1]],
+          tags: tagAnnotations.length > 0 ? tagAnnotations.map(tag => tag.tag) : [ann.path.split("/")[1]],
         };
       }
     }

--- a/packages/parser/spec/parser.spec.ts
+++ b/packages/parser/spec/parser.spec.ts
@@ -982,6 +982,63 @@ describe(Parser, () => {
     );
   });
 
+  test("handles functions with @tag", () => {
+    expectParses(
+      `
+        @tag Users
+        @tag Admin
+        @description Promotes a user to admin.
+        fn promoteToAdmin(id: uuid)
+        fn other(): int
+      `,
+      {
+        annotations: {
+          "fn.promoteToAdmin": [
+            { type: "tag", value: "Users" },
+            { type: "tag", value: "Admin" },
+            { type: "description", value: "Promotes a user to admin." },
+          ],
+        },
+        errors: ["Fatal"],
+        functionTable: {
+          promoteToAdmin: {
+            args: {
+              id: "uuid",
+            },
+            ret: "void",
+          },
+          other: {
+            args: {},
+            ret: "int",
+          },
+        },
+        typeTable: {},
+      },
+    );
+  });
+
+  test("doesn't allow @tag without a value", () => {
+    expectDoesntParse(
+      `
+        @tag
+        fn doIt(): string
+      `,
+      "@tag annotation needs a value",
+    );
+  });
+
+  test("doesn't allow @tag outside of functions", () => {
+    expectDoesntParse(
+      `
+        @tag Users
+        type User {
+          id: uuid
+        }
+      `,
+      "Cannot have @tag",
+    );
+  });
+
   test("handles recursive types", () => {
     expectParses(
       `

--- a/packages/parser/src/ast.ts
+++ b/packages/parser/src/ast.ts
@@ -53,6 +53,12 @@ export class ThrowsAnnotation extends Annotation {
   }
 }
 
+export class TagAnnotation extends Annotation {
+  constructor(public tag: string) {
+    super();
+  }
+}
+
 export class ArgDescriptionAnnotation extends Annotation {
   constructor(
     public argName: string,

--- a/packages/parser/src/json.ts
+++ b/packages/parser/src/json.ts
@@ -14,6 +14,7 @@ import {
   OptionalType,
   RestAnnotation,
   StructType,
+  TagAnnotation,
   ThrowsAnnotation,
   TypeDefinition,
   TypeReference,
@@ -46,6 +47,10 @@ type AnnotationJson =
       value: string;
     }
   | {
+      type: "tag";
+      value: string;
+    }
+  | {
       type: "hidden";
       value: null;
     }
@@ -70,6 +75,8 @@ function annotationToJson(ann: Annotation): AnnotationJson {
     return { type: "description", value: ann.text };
   } else if (ann instanceof ThrowsAnnotation) {
     return { type: "throws", value: ann.error };
+  } else if (ann instanceof TagAnnotation) {
+    return { type: "tag", value: ann.tag };
   } else if (ann instanceof RestAnnotation) {
     return {
       type: "rest",
@@ -97,6 +104,8 @@ function annotationFromJson(json: AnnotationJson | DeepReadonly<AnnotationJson>)
       return new DescriptionAnnotation(json.value);
     case "throws":
       return new ThrowsAnnotation(json.value);
+    case "tag":
+      return new TagAnnotation(json.value);
     case "rest": {
       const { method, path, pathVariables, queryVariables, headers, bodyVariable } = json.value;
 

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -17,6 +17,7 @@ import {
   OptionalType,
   Spread,
   StructType,
+  TagAnnotation,
   ThrowsAnnotation,
   TypeDefinition,
   TypeReference,
@@ -210,6 +211,13 @@ export class Parser {
           break;
         case "throws":
           this.annotations.push(new ThrowsAnnotation(body).at(this.token));
+          break;
+        case "tag":
+          if (body === "") {
+            throw new ParserError(`@tag annotation needs a value at ${this.token.location}`);
+          }
+
+          this.annotations.push(new TagAnnotation(body).at(this.token));
           break;
         case "rest":
           try {

--- a/packages/parser/src/semantic/09_validate_annotations.ts
+++ b/packages/parser/src/semantic/09_validate_annotations.ts
@@ -24,6 +24,7 @@ import {
   OptionalType,
   RestAnnotation,
   StringPrimitiveType,
+  TagAnnotation,
   ThrowsAnnotation,
   TypeDefinition,
   TypeReference,
@@ -134,6 +135,8 @@ export class ValidateAnnotationsVisitor extends Visitor {
             throw new SemanticError(`A GET rest endpoint must return something at ${annotation.location}`);
           }
         } else if (annotation instanceof HiddenAnnotation) {
+          // Ok
+        } else if (annotation instanceof TagAnnotation) {
           // Ok
         } else {
           throw new SemanticError(`Cannot have @${annotation.constructor.name.replace("Annotation", "").toLowerCase()} at ${annotation.location}`);

--- a/packages/playground/angular.json
+++ b/packages/playground/angular.json
@@ -87,7 +87,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumError": "6kb"
                 }
               ],
               "fileReplacements": [

--- a/packages/playground/src/app/tab-home/tab-home.component.html
+++ b/packages/playground/src/app/tab-home/tab-home.component.html
@@ -1,14 +1,22 @@
 <as-split [direction]="isBelowMd ? 'vertical' : 'horizontal'" unit="pixel">
   <as-split-area [size]="isBelowMd ? 130 : 350">
     <aside>
-      <nav>
-        <form>
-          <input type="search" placeholder="Buscar&#8230;" [(ngModel)]="searchText" [ngModelOptions]="{ standalone: true }" />
-        </form>
+      <form>
+        <input type="search" placeholder="Buscar&#8230;" [(ngModel)]="searchText" [ngModelOptions]="{ standalone: true }" />
+        <button
+          *ngIf="hasTags"
+          type="button"
+          class="collapse-toggle"
+          [matTooltip]="allGroupsCollapsed ? 'Expandir todas' : 'Recolher todas'"
+          (click)="toggleAllGroups()"
+        >
+          <mat-icon>{{ allGroupsCollapsed ? "unfold_more" : "unfold_less" }}</mat-icon>
+        </button>
+      </form>
 
-        <ul>
+      <nav>
+        <ng-template #fnItem let-fn>
           <li
-            *ngFor="let fn of fnTable | appFilter: searchText"
             (click)="this.selectedFunction = fn"
             [ngClass]="{ active: this.selectedFunction?.name === fn.name }"
             mat-ripple
@@ -16,7 +24,33 @@
             <span class="fn-call">{{ fn.name }}</span>
             <span class="fn-description" *ngIf="fn.description">{{ fn.description }}</span>
           </li>
+        </ng-template>
+
+        <ul *ngIf="!hasTags">
+          <ng-container *ngFor="let fn of fnTable | appFilter: searchText">
+            <ng-container *ngTemplateOutlet="fnItem; context: { $implicit: fn }"></ng-container>
+          </ng-container>
         </ul>
+
+        <ng-container *ngIf="hasTags">
+          <details
+            class="fn-group"
+            *ngFor="let group of fnGroups"
+            [open]="isGroupOpen(group)"
+            [hidden]="(group.functions | appFilter: searchText).length === 0"
+            (toggle)="onGroupToggle(group, $event)"
+          >
+            <summary class="fn-group-title">
+              <span class="fn-group-name">{{ group.name }}</span>
+              <span class="fn-group-count">{{ (group.functions | appFilter: searchText).length }}</span>
+            </summary>
+            <ul>
+              <ng-container *ngFor="let fn of group.functions | appFilter: searchText">
+                <ng-container *ngTemplateOutlet="fnItem; context: { $implicit: fn }"></ng-container>
+              </ng-container>
+            </ul>
+          </details>
+        </ng-container>
       </nav>
     </aside>
   </as-split-area>

--- a/packages/playground/src/app/tab-home/tab-home.component.scss
+++ b/packages/playground/src/app/tab-home/tab-home.component.scss
@@ -8,34 +8,27 @@
 }
 
 aside {
-  display: block;
+  display: flex;
+  flex-direction: column;
   background: lighten($color-primary, 5%);
   height: 100%;
-  overflow-y: auto;
-  overflow-x: hidden;
-  scrollbar-width: thin;
-}
+  overflow: hidden;
 
-nav {
-  display: block;
-  width: 100%;
-
+  // Search bar lives outside the scroll region so it stays fixed at the top
+  // and the group titles can stick to top: 0 of the list without a magic offset.
   form {
-    display: block;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
     width: 100%;
     padding: 10px;
 
     background: lighten($color-primary, 5%);
     border-bottom: 1px solid lighten($color-primary, 15%);
 
-    position: -webkit-sticky;
-    position: sticky;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 2;
-
     input {
+      flex: 1 1 auto;
       display: block;
       background: lighten($color-primary, 15%);
 
@@ -45,6 +38,131 @@ nav {
       width: 100%;
       padding: 5px;
     }
+
+    .collapse-toggle {
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+
+      width: 32px;
+      height: 32px;
+      padding: 0;
+
+      background: lighten($color-primary, 15%);
+      border: 0 none;
+      border-radius: 4px;
+      color: #bbb;
+      cursor: pointer;
+
+      transition:
+        background-color 0.15s ease,
+        color 0.15s ease;
+
+      &:hover {
+        background: lighten($color-primary, 20%);
+        color: #fff;
+      }
+
+      mat-icon {
+        font-size: 20px;
+        width: 20px;
+        height: 20px;
+        line-height: 20px;
+      }
+    }
+  }
+}
+
+nav {
+  display: block;
+  width: 100%;
+
+  // Scroll container for the function list.
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+
+  // Prevent the scroll-anchoring algorithm from picking a sticky category
+  // header as its anchor, which makes the list jump when toggling a group.
+  overflow-anchor: none;
+
+  $color-category-accent: #569cd6;
+
+  summary.fn-group-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    margin: 0;
+    padding: 10px 10px 10px 12px;
+    background: lighten($color-primary, 13%);
+    border-bottom: 1px solid lighten($color-primary, 20%);
+    border-left: 3px solid $color-category-accent;
+
+    color: #ddd;
+    font-weight: 600;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+
+    cursor: pointer;
+    user-select: none;
+    list-style: none; // hide default disclosure marker (Firefox)
+
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0; // the search bar is outside this scroll container, so no offset needed
+    z-index: 1;
+
+    transition: background-color 0.15s ease;
+
+    &:hover {
+      background: lighten($color-primary, 17%);
+    }
+
+    &::-webkit-details-marker {
+      display: none; // hide default disclosure marker (Chrome/Safari)
+    }
+
+    &::before {
+      content: "";
+      flex: 0 0 auto;
+      width: 0;
+      height: 0;
+      border-left: 4px solid currentColor;
+      border-top: 4px solid transparent;
+      border-bottom: 4px solid transparent;
+      transition: transform 0.15s ease;
+    }
+
+    .fn-group-name {
+      flex: 1 1 auto;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .fn-group-count {
+      flex: 0 0 auto;
+
+      padding: 1px 7px;
+      border-radius: 10px;
+      background: rgba($color-category-accent, 0.15);
+
+      color: $color-category-accent;
+      font-size: 0.7rem;
+      font-weight: 600;
+    }
+  }
+
+  details[open] > summary.fn-group-title::before {
+    transform: rotate(90deg);
+  }
+
+  // Indent functions that live under a category so the hierarchy reads clearly.
+  details > ul li {
+    padding-left: 32px;
   }
 
   ul {

--- a/packages/playground/src/app/tab-home/tab-home.component.ts
+++ b/packages/playground/src/app/tab-home/tab-home.component.ts
@@ -19,12 +19,20 @@ interface EasyFunctionTableItem {
   name: string;
   description?: string;
   labels: Array<{ name: string; type: string; dataType?: Type }>;
+  tags: string[];
   args: EasyFunctionTableItemType[];
   argsStr: string;
   argsFields: Field[];
   returns: Omit<EasyFunctionTableItemType, "name">;
   examples: Record<string, string>;
 }
+
+interface FunctionGroup {
+  name: string;
+  functions: EasyFunctionTableItem[];
+}
+
+const untaggedGroupName = "(Sem tags)";
 
 @Component({
   selector: "app-tab-home",
@@ -41,6 +49,9 @@ export class TabHomeComponent implements OnInit, OnDestroy, AfterViewInit {
   runFunction = new EventEmitter<string>();
 
   fnTable!: EasyFunctionTableItem[];
+  fnGroups: FunctionGroup[] = [];
+  hasTags = false;
+  collapsedGroups = new Set<string>();
   selectedFunction?: EasyFunctionTableItem;
   searchText = "";
 
@@ -64,6 +75,7 @@ export class TabHomeComponent implements OnInit, OnDestroy, AfterViewInit {
       }
 
       this.selectedFunction = undefined;
+      this.collapsedGroups.clear();
 
       this.fnTable = state.astRoot.operations
         .sort((a, b) => a.name.localeCompare(b.name))
@@ -99,7 +111,7 @@ export class TabHomeComponent implements OnInit, OnDestroy, AfterViewInit {
             },
             labels:
               annotations
-                ?.filter(ann => ["rest", "throws"].includes(ann.type))
+                ?.filter(ann => ["rest", "throws", "tag"].includes(ann.type))
                 .map(ann => {
                   if (ann.type === "rest") {
                     return {
@@ -112,6 +124,11 @@ export class TabHomeComponent implements OnInit, OnDestroy, AfterViewInit {
                       type: ann.value,
                       dataType: state.astRoot.errors.find(error => error.name === ann.value)?.dataType,
                     };
+                  } else if (ann.type === "tag") {
+                    return {
+                      name: "TAG",
+                      type: ann.value,
+                    };
                   }
 
                   return {
@@ -119,6 +136,7 @@ export class TabHomeComponent implements OnInit, OnDestroy, AfterViewInit {
                     type: "?",
                   }; // shoudn't happen
                 }) ?? [],
+            tags: annotations?.filter(ann => ann.type === "tag").map(ann => ann.value as string) ?? [],
             throws: annotations?.find(ann => ann.type === "throws")?.value as string,
             examples: {
               typeScript: this.sdkgen.getTypeScriptCode(operation.name, argsExampleObject),
@@ -129,7 +147,76 @@ export class TabHomeComponent implements OnInit, OnDestroy, AfterViewInit {
           };
         })
         .filter(x => Boolean(x)) as EasyFunctionTableItem[];
+
+      this.hasTags = this.fnTable.some(fn => fn.tags.length > 0);
+      this.fnGroups = this.buildGroups(this.fnTable);
     });
+  }
+
+  private buildGroups(fnTable: EasyFunctionTableItem[]): FunctionGroup[] {
+    const groupsMap = new Map<string, EasyFunctionTableItem[]>();
+
+    for (const fn of fnTable) {
+      const tags = fn.tags.length > 0 ? fn.tags : [untaggedGroupName];
+
+      for (const tag of tags) {
+        const functions = groupsMap.get(tag) ?? [];
+
+        functions.push(fn);
+        groupsMap.set(tag, functions);
+      }
+    }
+
+    return [...groupsMap.entries()]
+      .sort(([a], [b]) => {
+        // Keep the untagged group last, sort the rest alphabetically.
+        if (a === untaggedGroupName) {
+          return 1;
+        }
+
+        if (b === untaggedGroupName) {
+          return -1;
+        }
+
+        return a.localeCompare(b);
+      })
+      .map(([name, functions]) => ({ name, functions }));
+  }
+
+  get allGroupsCollapsed(): boolean {
+    return this.fnGroups.length > 0 && this.fnGroups.every(group => this.collapsedGroups.has(group.name));
+  }
+
+  toggleAllGroups(): void {
+    if (this.allGroupsCollapsed) {
+      this.collapsedGroups.clear();
+    } else {
+      for (const group of this.fnGroups) {
+        this.collapsedGroups.add(group.name);
+      }
+    }
+  }
+
+  isGroupOpen(group: FunctionGroup): boolean {
+    // While searching, keep every group expanded so matches are always visible.
+    if (this.searchText) {
+      return true;
+    }
+
+    return !this.collapsedGroups.has(group.name);
+  }
+
+  onGroupToggle(group: FunctionGroup, event: Event): void {
+    // Ignore the programmatic toggles triggered while a search forces groups open.
+    if (this.searchText) {
+      return;
+    }
+
+    if ((event.target as HTMLDetailsElement).open) {
+      this.collapsedGroups.delete(group.name);
+    } else {
+      this.collapsedGroups.add(group.name);
+    }
   }
 
   ngOnDestroy() {

--- a/packages/vscode-ext/syntaxes/sdkgen.tmLanguage.json
+++ b/packages/vscode-ext/syntaxes/sdkgen.tmLanguage.json
@@ -194,6 +194,30 @@
 					}
 				},
 				{
+					"name": "meta.annotation.tag",
+					"match": "(@tag) (.*)\\n",
+					"captures": {
+						"1": {
+							"name": "constant.numeric"
+						},
+						"2": {
+							"name": "entity.name.type"
+						}
+					}
+				},
+				{
+					"name": "meta.annotation.statusCode",
+					"match": "(@statusCode) (\\d+)\n",
+					"captures": {
+						"1": {
+							"name": "constant.numeric"
+						},
+						"2": {
+							"name": "constant.numeric"
+						}
+					}
+				},
+				{
 					"name": "meta.annotations.rest",
 					"begin": "(@rest) (\\w+)",
 					"beginCaptures": {


### PR DESCRIPTION
This PR implements an `@tag` annotation for methods, for example:

```sdkgen
@tag Communication
fn sayHello(name: string): string

@tag Communication
fn sayGoodbye(name: string): string

@tag Basic Math
fn add(a: int, b: int): int

@tag Basic Math
fn subtract(a: int, b: int): int
```

Multiple `@tag`'s are also allowed in a function.

Tags are then used to group functions in Playground:

<img width="3600" height="1966" alt="image" src="https://github.com/user-attachments/assets/aa862b14-733b-41c1-946e-3a6bc0879637" />

These groups are collapsible:

<img width="3600" height="1966" alt="image" src="https://github.com/user-attachments/assets/f40b7a29-44ae-40e6-a996-ab246e92f0d7" />

And searchable:

<img width="3600" height="1966" alt="image" src="https://github.com/user-attachments/assets/1e5feb61-5044-4896-a46b-efe684425008" />

The VS Code extension was updated to add syntax highlighting to the @tag annotation, as well as the @statusCode that was missing.