### PR TITLE
fix: allow @statusCode on errors that carry data

### DIFF
--- a/docs/aprofundando/annotations.md
+++ b/docs/aprofundando/annotations.md
@@ -99,6 +99,11 @@ Pode ser adicionado na declaração de erros para designar o código de status q
 ```
 @statusCode 404
 error NotFound
+
+@statusCode 429
+error RateLimited {
+  retryAfter: uint
+}
 ```
 
 ## `@rest`

--- a/packages/node-runtime/spec/rest/api.sdkgen
+++ b/packages/node-runtime/spec/rest/api.sdkgen
@@ -1,5 +1,10 @@
 error TestError
 
+@statusCode 429
+error ThrottledError {
+    retryAfter: uint
+}
+
 @rest GET /add1/{first}/{second}
 @rest GET /add2?{first}&{second}
 @rest GET /add3?{first} [header x-second: {second}]

--- a/packages/node-runtime/spec/rest/rest.spec.ts
+++ b/packages/node-runtime/spec/rest/rest.spec.ts
@@ -20,7 +20,7 @@ import { SdkgenHttpServer } from "../../src";
 const ast = new Parser(`${__dirname}/api.sdkgen`).parse();
 
 writeFileSync(`${__dirname}/api.ts`, generateNodeServerSource(ast).replace(/@sdkgen\/node-runtime/gu, "../../src"));
-const { api, TestError } = require(`${__dirname}/api.ts`);
+const { api, TestError, ThrottledError } = require(`${__dirname}/api.ts`);
 
 unlinkSync(`${__dirname}/api.ts`);
 
@@ -43,6 +43,10 @@ api.fn.obj = async (_ctx: Context, { obj }: { obj: { val: number } }) => {
 
   if (obj.val === -100) {
     throw new TestError("Value is -100 ~ TestError");
+  }
+
+  if (obj.val === -429) {
+    throw new ThrottledError("Value is -429 ~ ThrottledError", { retryAfter: 30 });
   }
 
   return obj;
@@ -292,6 +296,16 @@ describe("Rest API", () => {
         "content-type": "application/json",
       },
       statusCode: 400,
+    },
+    {
+      data: `{"val":-429}`,
+      method: "POST",
+      path: "/obj",
+      result: `{"data":{"retryAfter":30},"message":"Value is -429 ~ ThrottledError","type":"ThrottledError"}`,
+      resultHeaders: {
+        "content-type": "application/json",
+      },
+      statusCode: 429,
     },
     {
       method: "POST",

--- a/packages/parser/spec/parser.spec.ts
+++ b/packages/parser/spec/parser.spec.ts
@@ -139,6 +139,35 @@ describe(Parser, () => {
     );
   });
 
+  test("handles annotations on errors that carry data", () => {
+    expectParses(
+      `
+        @statusCode 404
+        error Foo
+        @statusCode 429
+        error Bar {
+          foo: string
+        }
+        @statusCode 400
+        error FooBar int
+      `,
+      {
+        annotations: {
+          "error.Foo": [{ type: "statusCode", value: 404 }],
+          "error.Bar": [{ type: "statusCode", value: 429 }],
+          "error.FooBar": [{ type: "statusCode", value: 400 }],
+        },
+        errors: ["Foo", ["Bar", "BarData"], ["FooBar", "int"], "Fatal"],
+        functionTable: {},
+        typeTable: {
+          BarData: {
+            foo: "string",
+          },
+        },
+      },
+    );
+  });
+
   test("handles combinations of all part", () => {
     expectParses(
       `

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -300,6 +300,12 @@ export class Parser {
 
     this.nextToken();
 
+    // Take the pending annotations before parsing the type: parseType() rejects any that are still
+    // pending, so leaving them would make `@statusCode 404 error Foo { ... }` fail to parse.
+    const { annotations } = this;
+
+    this.annotations = [];
+
     let type: Type = new VoidPrimitiveType();
 
     if (
@@ -313,8 +319,8 @@ export class Parser {
 
     const node = new ErrorNode(name, type).at(errorToken);
 
-    node.annotations = this.annotations;
-    this.annotations = [];
+    node.annotations = annotations;
+
     return node;
   }
 


### PR DESCRIPTION
## Problem

`@statusCode` only worked on errors declared without a type. Any error carrying data failed to parse:

```
@statusCode 429
error RateLimited { retryAfter: uint }
```
```
ParserError: Cannot have annotations at api.sdkgen:1:1
    at Parser.checkCannotHaveAnnotationsHere (parser.ts:259)
    at Parser.parseType (parser.ts:578)
    at Parser.parseError (parser.ts:311)
```

`parseError()` assigned `node.annotations` and cleared `this.annotations` *after* parsing the type, so `parseType()` — which starts with `checkCannotHaveAnnotationsHere()` — still saw them pending. Errors with no type never reach `parseType()`, which is why the void form worked and nothing else did.

The docs state the annotation "pode ser adicionado na declaração de erros" with no such restriction, so this looks like an oversight rather than a deliberate limitation.

## Fix

Take the annotations before parsing the type, the way `parseTypeDefinition()` and `parseOperation()` already do.

No runtime change was needed: `json.ts` already round-trips `StatusCodeAnnotation`, and the REST layer already reads it back from the AST via `apiConfig.ast.errors`.

## Tests

- `packages/parser`: parses `@statusCode` on all three error forms (void, inline struct, named type) and asserts the annotations land in the AST JSON. `expectParses` also covers the `astToJson`/`jsonToAst` round-trip.
- `packages/node-runtime`: a `@statusCode 429` error carrying data now answers `429` over REST. There was no end-to-end coverage of the annotation before, which is how this went unnoticed.

Verified the parser test fails with `Cannot have annotations at -:4:9` without the fix, and passes with it. Full parser suite is green (252 tests); in node-runtime only the pre-existing timezone-dependent `Process Date`/`Process Datetime` tests fail locally (they assume the machine runs in UTC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)