### PR TITLE
fix: search playground functions by their fields instead of serialized JSON

### DIFF
--- a/packages/playground/src/app/filter.pipe.ts
+++ b/packages/playground/src/app/filter.pipe.ts
@@ -1,27 +1,48 @@
 import { PipeTransform, Pipe } from "@angular/core";
 
+export interface SearchableItem {
+  /**
+   * Text with every value this item should be searchable by, already passed through
+   * {@link normalizeSearchText}. It is compared as-is on every keystroke, so normalizing it
+   * once when the item is built keeps that path free of per-item string work.
+   */
+  searchIndex: string;
+}
+
+/**
+ * Normalizes text for searching: strips diacritics and lowercases, so that
+ * "descricao" matches "descrição".
+ *
+ * Lowercasing is deliberately locale-independent. Under a Turkish locale `toLocaleLowerCase`
+ * maps "I" to the dotless "ı", so a user typing "identity" would stop matching "getIdentity".
+ */
+export function normalizeSearchText(text: string): string {
+  return text
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+}
+
 @Pipe({ name: "appFilter" })
 export class FilterPipe implements PipeTransform {
   /**
    * Pipe filters the list of elements based on the search text provided
    *
-   * @param items list of elements to search in
-   * @param searchText search string
+   * @param items list of elements to search in, each one carrying its own normalized `searchIndex`
+   * @param searchText search string, whose terms must all be present in the item
    * @returns list of elements filtered by search text or []
    */
-  transform(items: any[] | null, searchText: string): any[] {
+  transform<T extends SearchableItem>(items: T[] | null, searchText: string): T[] {
     if (!items) {
       return [];
     }
 
-    if (!searchText) {
+    const terms = normalizeSearchText(searchText).split(/\s+/u).filter(Boolean);
+
+    if (terms.length === 0) {
       return items;
     }
 
-    const search = searchText.toLocaleLowerCase();
-
-    return items.filter(it => {
-      return JSON.stringify(it).toLocaleLowerCase().includes(search);
-    });
+    return items.filter(it => terms.every(term => it.searchIndex.includes(term)));
   }
 }

--- a/packages/playground/src/app/tab-home/tab-home.component.ts
+++ b/packages/playground/src/app/tab-home/tab-home.component.ts
@@ -3,6 +3,7 @@ import { MatDialog } from "@angular/material/dialog";
 import { Field, Type } from "@sdkgen/parser";
 import { Subscription } from "rxjs";
 
+import { normalizeSearchText, SearchableItem } from "../filter.pipe";
 import { ResponsiveService } from "../responsive.service";
 import { getTypeDoc } from "../sdkgen.docs";
 import { SdkgenService } from "../sdkgen.service";
@@ -15,7 +16,7 @@ interface EasyFunctionTableItemType {
   rawType: Type;
 }
 
-interface EasyFunctionTableItem {
+interface EasyFunctionTableItem extends SearchableItem {
   name: string;
   description?: string;
   labels: Array<{ name: string; type: string; dataType?: Type }>;
@@ -33,6 +34,23 @@ interface FunctionGroup {
 }
 
 const untaggedGroupName = "(Sem tags)";
+
+/**
+ * Indexes a function by what the list actually shows — its name and description — plus the tag it
+ * is grouped under and its REST route. Serializing the whole item instead would both blow up on
+ * recursive types and match on noise such as the example code.
+ */
+function buildSearchIndex(fn: Omit<EasyFunctionTableItem, "searchIndex">): string {
+  return normalizeSearchText(
+    [
+      fn.name,
+      fn.description ?? "",
+      ...fn.tags,
+      // A @rest route is worth searching by ("what handles /users?"); the other labels are not.
+      ...fn.labels.filter(label => label.name === "REST").map(label => label.type),
+    ].join(" "),
+  );
+}
 
 @Component({
   selector: "app-tab-home",
@@ -77,7 +95,7 @@ export class TabHomeComponent implements OnInit, OnDestroy, AfterViewInit {
       this.selectedFunction = undefined;
       this.collapsedGroups.clear();
 
-      this.fnTable = state.astRoot.operations
+      const operations = state.astRoot.operations
         .sort((a, b) => a.name.localeCompare(b.name))
         .map(operation => {
           const annotations = state.astJson.annotations[`fn.${operation.name}`];
@@ -134,7 +152,7 @@ export class TabHomeComponent implements OnInit, OnDestroy, AfterViewInit {
                   return {
                     name: "?",
                     type: "?",
-                  }; // shoudn't happen
+                  }; // shouldn't happen
                 }) ?? [],
             tags: annotations?.filter(ann => ann.type === "tag").map(ann => ann.value as string) ?? [],
             throws: annotations?.find(ann => ann.type === "throws")?.value as string,
@@ -146,7 +164,9 @@ export class TabHomeComponent implements OnInit, OnDestroy, AfterViewInit {
             },
           };
         })
-        .filter(x => Boolean(x)) as EasyFunctionTableItem[];
+        .filter(x => Boolean(x)) as Array<Omit<EasyFunctionTableItem, "searchIndex">>;
+
+      this.fnTable = operations.map(fn => ({ ...fn, searchIndex: buildSearchIndex(fn) }));
 
       this.hasTags = this.fnTable.some(fn => fn.tags.length > 0);
       this.fnGroups = this.buildGroups(this.fnTable);


### PR DESCRIPTION
## Problem

The playground's function-list filter matched against `JSON.stringify(item)`, which failed in two independent ways.

**It threw on any API with a recursive type.** Items carry the full parser type graph in `rawType`, so a type like `type Category { parent: Category? }` cycles:

```
TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Array'
    |     index 2 -> object with constructor 'Field'
    |     property 'type' -> object with constructor 'Object'
    --- property 'fields' closes the circle
```

Because the pipe short-circuits on empty input, the list rendered fine until you typed the first character — then it threw during change detection and the sidebar broke.

**Where it didn't throw, it matched everything.** The serialized blob included the generated example code and the whole type graph, so these all matched every function in the API:

| query | matched `getUser`? |
|---|---|
| `print` | ✅ (from `print("todo");` in the Dart/Swift samples) |
| `await` / `client` | ✅ (from `await client.getUser(...)`) |
| `rawType` | ✅ (object keys of the serialized type graph) |

## Fix

Each function now carries a `searchIndex`, built once when the AST loads from the values the list actually shows — name, description, the tag it is grouped under, and its REST route:

```ts
function buildSearchIndex(fn: Omit<EasyFunctionTableItem, "searchIndex">): string {
  return normalizeSearchText(
    [
      fn.name,
      fn.description ?? "",
      ...fn.tags,
      // A @rest route is worth searching by ("what handles /users?"); the other labels are not.
      ...fn.labels.filter(label => label.name === "REST").map(label => label.type),
    ].join(" "),
  );
}
```

The pipe compares against that string instead of serializing. Two behaviour changes come along for free, both of which matter for this UI:

- **Accent-insensitive** — `usuario` finds `usuário`, which the pt-BR interface needs.
- **Multi-term** — `cria pedido` finds `createOrder`; terms may appear in any order.

Normalization happens at index-build time rather than per filter pass. On a 500-function API that is ~4 ms saved per keystroke (three pipe instances re-filter each group on every change):

```
normalize on every filter : 4.12 ms
pre-normalized index      : 0.04 ms
```

Lowercasing is deliberately locale-independent. Under a Turkish locale `toLocaleLowerCase` maps `I` to the dotless `ı`, so `getIdentity` folds to `getıdentity` and a user typing `identity` matches nothing. `toLowerCase` is identical for Portuguese accents (`AÇÃO` → `acao` either way).

## Trade-off

Functions are no longer findable by argument name, argument/return type, or thrown error — `money` and `usernotfound` now match nothing. That is deliberate: the sidebar row renders only the name and description, so matching on invisible fields produced hits with nothing on screen to explain them. REST routes were kept because the path is a value the author typed in the `.sdkgen` file, so a hit is still explicable.

## Verification

`ng build`, eslint and prettier all pass. Behaviour was exercised against an AST parsed from a real `.sdkgen` file containing tags, accented descriptions, a `@rest` route, `@throws`, and the recursive type that used to crash:

```
"usuario"      -> ["getUser"]        "todo"         -> []
"USUÁRIO"      -> ["getUser"]        "await"        -> []
"/users/"      -> ["getUser"]        "category"     -> ["getCategory"]   (used to throw)
"cria pedido"  -> ["createOrder"]    "money"        -> []                (intentional, see above)
```

Not verified in a live browser — that needs a running server for the playground to fetch `ast.json` from — so this is unit-level verification against real parser output rather than a click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)